### PR TITLE
[MI] Scrape individual contact pages for Republican senator email

### DIFF
--- a/openstates/mi/legislators.py
+++ b/openstates/mi/legislators.py
@@ -103,5 +103,8 @@ class MILegislatorScraper(LegislatorScraper):
                            email=email)
 
 
+            if email:
+                leg.add_source(contact_url)
+
             leg.add_source(url)
             self.save_legislator(leg)

--- a/openstates/mi/legislators.py
+++ b/openstates/mi/legislators.py
@@ -60,6 +60,8 @@ class MILegislatorScraper(LegislatorScraper):
 
     def scrape_upper(self, chamber, term):
         url = 'http://www.senate.michigan.gov/members/memberlist.htm'
+        r_contact_url_pattern = 'http://www.misenategop.com/senators/contact.asp?District=%s'
+
         html = self.urlopen(url)
         doc = lxml.html.fromstring(html)
         for row in doc.xpath('//table[@width=550]/tr')[1:39]:
@@ -75,6 +77,19 @@ class MILegislatorScraper(LegislatorScraper):
             office_phone = phone.text
             office_fax = fax.text
             office_loc = loc.text
+
+            email = None
+            if party == abbr['R']:
+                contact_url = r_contact_url_pattern % district
+                contact_html = self.urlopen(contact_url)
+                contact_doc = lxml.html.fromstring(contact_html)
+                email_link = contact_doc.xpath(".//*[@id='yui-main']/div/div/table/tr[9]/td[2]/p/a")
+                if(email_link):
+                    email_link_attr = email_link[0].attrib['href']
+                    if email_link_attr[0:7] == 'mailto:':
+                        email = email_link_attr[7:]
+
+
             leg = Legislator(term=term, chamber=chamber,
                              district=district,
                              full_name=name,
@@ -84,7 +99,8 @@ class MILegislatorScraper(LegislatorScraper):
             leg.add_office('capitol', 'Capitol Office',
                            address=office_loc,
                            fax=office_fax,
-                           phone=office_phone)
+                           phone=office_phone,
+                           email=email)
 
 
             leg.add_source(url)


### PR DESCRIPTION
This should add some emails to the senators. It makes another request to the individual contact pages of the legislator and scrapes their email address from there. 

It uses an xpath to find where the "mailto: link" should be and checks it to see if it is in fact a mailto link. 

This only works for Republicans, as I have not yet found a way to determine Democrat emails. In addition, while the Republicans sometimes publish an email address here, some do not, and some link to a contact form. 

As it stands, I believe this will add the availability of 9 emails. 

To write this, I had to extract the basic code, and  test it separately, as the methods described in the "Contributing" guide did not seem to work (eg.billy-update )
