### PR TITLE
NE: A bill action of "Bill withdrawn" should map to the action type: bill:withdrawn

### DIFF
--- a/openstates/ne/bills.py
+++ b/openstates/ne/bills.py
@@ -143,6 +143,8 @@ class NEBillScraper(BillScraper):
             action_type = 'governor:vetoed'
         elif 'Failed' in action:
             action_type = 'bill:failed'
+        elif 'Bill withdrawn' in action:
+            action_type = 'bill:withdrawn'
         else:
             action_type = ''
         return action_type


### PR DESCRIPTION
Currently if the text is "Bill withdrawn", the type is "other". This should be "bill:withdrawn".