### PR TITLE
KY: Small events scraper fix, and error to prevent identical event scraping

### DIFF
--- a/openstates/ky/__init__.py
+++ b/openstates/ky/__init__.py
@@ -28,6 +28,12 @@ metadata = dict(
                 '2013RS', '2013SS', '2014RS',
             ]
         ),
+        dict(
+            name='2015-2016', start_year=2015, end_year=2016,
+            sessions=[
+                '2015RS'
+            ]
+        ),
     ],
     session_details={
         '2011 Regular Session': {'type': 'primary',
@@ -54,6 +60,10 @@ metadata = dict(
         '2014RS': {'type': 'primary',
                    'display_name': '2014 Regular Session',
                    '_scraped_name': '2014 Regular Session ',
+                  },
+        '2015RS': {'type': 'primary',
+                   'display_name': '2015 Regular Session',
+                   '_scraped_name': '2015 Regular Session ',
                   },
     },
     feature_flags=['subjects', 'events', 'influenceexplorer'],

--- a/openstates/ky/events.py
+++ b/openstates/ky/events.py
@@ -12,19 +12,12 @@ class KYEventScraper(EventScraper):
 
     _tz = pytz.timezone('US/Eastern')
 
-    def scrape(self, chamber, session):
+    def scrape(self, session, chambers):
         url = "http://www.lrc.ky.gov/legislative_calendar/index.aspx"
         page = self.urlopen(url)
         page = lxml.html.fromstring(page)
 
         for div in page.xpath("//div[@style = 'MARGIN-LEFT: 20px']"):
-            raise NotImplementedError(
-                    "Events are getting scraped multiple times, "
-                    "twice for each chamber and twice more for an "
-                    "'other' chamber. We'll need more 2015RS events listed "
-                    "in order to diagnose and fix this."
-                    )
-
             date = div.xpath("string(../../span[1])").strip()
 
             try:
@@ -55,7 +48,6 @@ class KYEventScraper(EventScraper):
             event.add_source(url)
 
             # desc is actually the ctty name.
-            event.add_participant('host', desc, 'committee',
-                                  chamber=chamber)
+            event.add_participant('host', desc, 'committee')
 
             self.save_event(event)

--- a/openstates/ky/events.py
+++ b/openstates/ky/events.py
@@ -18,6 +18,13 @@ class KYEventScraper(EventScraper):
         page = lxml.html.fromstring(page)
 
         for div in page.xpath("//div[@style = 'MARGIN-LEFT: 20px']"):
+            raise NotImplementedError(
+                    "Events are getting scraped multiple times, "
+                    "twice for each chamber and twice more for an "
+                    "'other' chamber. We'll need more 2015RS events listed "
+                    "in order to diagnose and fix this."
+                    )
+
             date = div.xpath("string(../../span[1])").strip()
 
             try:
@@ -25,6 +32,9 @@ class KYEventScraper(EventScraper):
             except ValueError:
                 # No meetings
                 continue
+
+            if time == "Noon":
+                time = "12:00pm"
 
             if ':' not in time:
                 self.warning('skipping event with invalid time: %s', time)


### PR DESCRIPTION
Currently all events are scraped three times, and attributed to multiple chambers. We can't fix this bug yet, though, since there isn't enough information up on the calendar site.