### PR TITLE
MI: 2015 Session can go back online

### DIFF
--- a/openstates/mi/events.py
+++ b/openstates/mi/events.py
@@ -108,7 +108,7 @@ class MIEventScraper(EventScraper, LXMLMixin):
             span = span[0]
         else:
             return
-        events = span.xpath("//a[contains(@href, 'committeemeeting')]")
+        events = span.xpath(".//a[contains(@href, 'committeemeeting')]")
         for event in events:
             url = event.attrib['href']
             if 'doPostBack' in url:

--- a/openstates/mi/legislators.py
+++ b/openstates/mi/legislators.py
@@ -38,7 +38,6 @@ class MILegislatorScraper(LegislatorScraper):
                 metainf[table[i]] = tds[i]
             district = str(int(metainf['district'].text_content().strip()))
             party = metainf['party'].text_content().strip()
-            office = metainf['location'].text_content().strip()
             phone = metainf['phone'].text_content().strip()
             email = metainf['email'].text_content().strip()
             leg_url = metainf['website'].xpath("./a")[0].attrib['href']
@@ -46,6 +45,19 @@ class MILegislatorScraper(LegislatorScraper):
             if name == 'Vacant':
                 self.info('district %s is vacant', district)
                 continue
+
+            office = metainf['location'].text_content().strip()
+            office = re.sub(
+                    ' HOB',
+                    ' Anderson House Office Building\n124 North Capitol Avenue\nLansing, MI 48933',
+                    office
+                    )
+            office = re.sub(
+                    ' CB',
+                    ' State Capitol Building\nLansing, MI 48909',
+                    office
+                    )
+
             leg = Legislator(term=term,
                              chamber=chamber,
                              full_name=name,
@@ -87,7 +99,19 @@ class MILegislatorScraper(LegislatorScraper):
             leg_url = member.xpath('a/@href')[0]
             office_phone = phone.text
             office_fax = fax.text
+            
             office_loc = loc.text
+            office_loc = re.sub(
+                    ' Farnum Bldg',
+                    ' Farnum Office Building\n125 West Allegan Street\nLansing, MI 48933',
+                    office_loc
+                    )
+            office_loc = re.sub(
+                    ' Capitol Bldg',
+                    ' State Capitol Building\nLansing, MI 48909',
+                    office_loc
+                    )
+
             leg = Legislator(term=term, chamber=chamber,
                              district=district,
                              full_name=name,

--- a/openstates/mi/legislators.py
+++ b/openstates/mi/legislators.py
@@ -65,7 +65,7 @@ class MILegislatorScraper(LegislatorScraper):
         url = 'http://www.senate.michigan.gov/senatorinfo.html'
         html = self.urlopen(url)
         doc = lxml.html.fromstring(html)
-        for row in doc.xpath("//table[@class='auto-style2']/tr")[4:]:
+        for row in doc.xpath('//table[not(@id="calendar")]//tr')[3:]:
             if len(row) != 6:
                 continue
 
@@ -78,6 +78,7 @@ class MILegislatorScraper(LegislatorScraper):
             party = abbr[party.text]
             district = dist.text_content().strip()
             name = member.text_content().strip()
+            name = re.sub(r'\s+', " ", name)
 
             if name == 'Vacant':
                 self.info('district %s is vacant', district)


### PR DESCRIPTION
No bad data ingested now. Committees still aren't posted, but that scraper now just errors from not finding anything.

Also, the janky bill scraper could be re-written to use this RSS, but we'd still have to keep all the current code in place for resolutions, which don't have an RSS. (We could also use this to completely revamp the events scraper.)
http://www.legislature.mi.gov/mileg.aspx?page=rssbills