### PR TITLE
fixes for #392 (MI committees) and AttributeError crash (GA committees)

### DIFF
--- a/openstates/ga/committees.py
+++ b/openstates/ga/committees.py
@@ -24,7 +24,7 @@ class GACommitteeScraper(CommitteeScraper):
         #    return  # If we get here, it's a problem.
         # Commenting this out for future debugging. - PRT
 
-        if committees.strip() == "":
+        if str(committees).strip() == "":
             raise ValueError("Error: No committee data for sid: %s" % (sid))
 
         committees = committees['CommitteeListing']

--- a/openstates/mi/committees.py
+++ b/openstates/mi/committees.py
@@ -81,6 +81,10 @@ class MICommitteeScraper(CommitteeScraper):
             if member_name == 'Committee Clerk':
                 continue
 
+            # skip phone links
+            if member.get("href").startswith("tel:"):
+                continue
+
             if 'Committee Chair' in member.tail:
                 role = 'chair'
             elif 'Majority Vice' in member.tail:


### PR DESCRIPTION
The scraper gets committee members from `<a>` tags. Looks like this broke when the site added `<a>` tags with phone numbers (`billy-update mi --committees` was crashing). Skipping those tags.