### PR TITLE
KY: fixed double space issue

### DIFF
--- a/openstates/ky/committees.py
+++ b/openstates/ky/committees.py
@@ -59,6 +59,7 @@ class KYCommitteeScraper(CommitteeScraper):
 
         for link in page.xpath("//a[contains(@href, 'Legislator')]"):
             name = re.sub(r'^(Rep\.|Sen\.) ', '', link.text).strip()
+            name = name.replace("  "," ")
             if not link.tail or not link.tail.strip():
                 role = 'member'
             elif link.tail.strip() == '[Chair]':


### PR DESCRIPTION
jumped the gun on the prev PR, now committee-member matching works for a few members incorrectly formatted on KY's site.