### PR TITLE
MD: events throw warning and do not scrape; minor bugfixes

### DIFF
--- a/openstates/md/__init__.py
+++ b/openstates/md/__init__.py
@@ -23,7 +23,7 @@ metadata = dict(
                                            '2012s1', '2012s2', '2013', '2014'],
          'start_year': 2011, 'end_year': 2014},
         {'name': '2015-2018', 'sessions': ['2015'],
-         'start_year': 2011, 'end_year': 2014},
+         'start_year': 2015, 'end_year': 2018},
     ],
     session_details={
         '2007': {'start_date': datetime.date(2007,1,10),

--- a/openstates/md/committees.py
+++ b/openstates/md/committees.py
@@ -47,11 +47,14 @@ class MDCommitteeScraper(CommitteeScraper):
             for row in rows[1:]:
                 name = row.getchildren()[0].text_content()
                 if name.endswith(' (Chair)'):
-                    name = name.strip(' (Chair)')
+                    name = name.replace(' (Chair)','')
                     role = 'chair'
                 elif name.endswith(' (Vice Chair)'):
-                    name = name.strip(' (Vice Chair)')
+                    name = name.replace(' (Vice Chair)','')
                     role = 'vice chair'
+                elif name.endswith(' (Co-Chair)'):
+                    name = name.replace(' (Co-Chair)','')
+                    role = 'co-chair'
                 else:
                     role = 'member'
                 com.add_member(name, role)

--- a/openstates/md/events.py
+++ b/openstates/md/events.py
@@ -21,6 +21,11 @@ class MDEventScraper(EventScraper, LXMLMixin):
     _tz = pytz.timezone('US/Eastern')
 
     def scrape(self, chamber, session):
+        self.logger.warning("MD's events schedule is a blob of hand-indented text and has changed from last year. Skipping for now.")
+        return
+
+
+
         if chamber != 'other':
             return None  # We're going to do it all on one shot.
 


### PR DESCRIPTION
Should we also turn events off? The hand-indented, blob-of-text that is MD's events schedule has completely changed, and will have to be completely redone if/when we want to scrape events