### PR TITLE
ID: no longer crashing

### DIFF
--- a/openstates/id/bills.py
+++ b/openstates/id/bills.py
@@ -88,7 +88,7 @@ _ACTIONS = (
 def get_action(actor, text):
     # the biggest issue with actions is that some lines seem to indicate more
     # than one action
-    print text
+    
 
     for pattern, action in _ACTIONS:
         match = re.match(pattern, text, re.I)


### PR DESCRIPTION
joint committee pages are all different and need custom scrapers. Fixed the one that was crashing, but there are some committees we still aren't scraping.