### PR TITLE
AZ: skipping committee votes with no action

### DIFF
--- a/openstates/az/bills.py
+++ b/openstates/az/bills.py
@@ -216,7 +216,14 @@ class AZBillScraper(BillScraper):
                     vote_url = row[0].xpath('string(a/@href)')
                     if vote_url:
                         date = utils.get_date(row[3])
-                        act = row[5].text_content().strip()
+                        try:
+                            act = row[5].text_content().strip()
+                        except IndexError:
+                            #not sure what to do if action is not specified
+                            #skipping and throwing a warning for now
+                            self.logger.warning("Vote has no action, skipping.")
+                            continue
+
                         a_type = get_action_type(act, 'COMMITTEES:')
                         act = get_verbose_action(act)
                         bill.add_action(actor,


### PR DESCRIPTION
AZ committee votes have explanations of actions. If no action is available, we're now skipping the vote. I think this is rare, because this is the first time we've encountered this problem, and I only saw it once.

Helpful if we decide we want to try to do something else with these?

Here are the possible actions:
http://www.azleg.gov/CommitteeActions.asp

Here's a vote with no action:
http://www.azleg.gov//FormatDocument.asp?inDoc=/legtext/52Leg/1r/bills/sb1204o.asp&Session_ID=114
