### PR TITLE
TX: Fix crash from irregular event time string

### DIFF
--- a/openstates/tx/events.py
+++ b/openstates/tx/events.py
@@ -128,6 +128,7 @@ class TXEventScraper(EventScraper, LXMLMixin):
                     "of the House and the Senate": "",
                     "or upon final adjourn./recess": "",
                     "or 30 minutes upon adjournment": "",
+                    "30 minutes upon adjourn.": "",
                     "or the Senate Finance Committee": "",
                     "During reading and referral of bills": "",
                     "and House Chambers, whichever is later.": "",


### PR DESCRIPTION
Trivial change. I'm going to pull this in right away so that our (many) Texas dependents can have their information back up; the scraper's been down since mid last week.