### PR TITLE
TX: Scrape fiscal notes, witness lists, and analyses

### DIFF
--- a/openstates/tx/bills.py
+++ b/openstates/tx/bills.py
@@ -1,115 +1,86 @@
-import re
-from urlparse import urljoin
 import datetime
 import ftplib
+import re
+import xml.etree.cElementTree as etree
 
 from billy.scrape import ScrapeError
 from billy.scrape.bills import BillScraper, Bill
 
-from .utils import chamber_name, parse_ftp_listing
-
-import lxml.etree
-
 
 class TXBillScraper(BillScraper):
     jurisdiction = 'tx'
-    _ftp_root = 'ftp.legis.state.tx.us'
+    _FTP_ROOT = 'ftp.legis.state.tx.us'
+    CHAMBERS = {'H': 'lower', 'S': 'lower'}
 
     def _get_ftp_files(self, root, dir_):
-        '''
-        Walk an FTP directory and its subdirectories, and yield the
-        paths to all files therein
-        '''
+        ''' Recursively traverse an FTP directory, returning all files '''
 
-        ftp = ftplib.FTP(self._ftp_root)
+        ftp = ftplib.FTP(self._FTP_ROOT)
         ftp.login()
-        ftp.cwd(dir_)
+        for item in self._crawl_ftp(ftp, root, dir_):
+            yield item
+
+    def _crawl_ftp(self, ftp, root, dir_):
         self.log('Searching an FTP folder for files ({})'.format(dir_))
+        ftp.cwd('/' + dir_)
 
         lines = []
         ftp.retrlines('LIST', lines.append)
         for line in lines:
-            name = line.split(' ')[-1]
-            if '<DIR>' in line:
-                for item in self._get_ftp_files(root, '/'.join([dir_, name])):
+            (_date, _time, is_dir, _file_size, name) = re.search(r'''(?x)
+                    ^(\d{2}-\d{2}-\d{2})\s+  # Date in mm-dd-yy
+                    (\d{2}:\d{2}[AP]M)\s+  # Time in hh:mmAM/PM
+                    (<DIR>)?\s+  # Directories will have an indicating flag
+                    (\d+)?\s+  # Files will have their size in bytes
+                    (.+?)\s*$  # Directory or file name is the remaining text
+                    ''', line).groups()
+            if is_dir:
+                for item in self._crawl_ftp(
+                        ftp, root, '/'.join([dir_, name])):
                     yield item
             else:
                 yield '/'.join(['ftp://' + root, dir_, name])
 
-    def scrape(self, chamber, session):
-        """Scrapes information on all bills for a given chamber and session."""
+    def scrape(self, session, chambers):
         self.validate_session(session)
 
-        if len(session) == 2:
-            session = '%sR' % session
+        session_code = session
+        if len(session_code) == 2:
+            session_code = session_code + 'R'
+        assert len(session_code) == 3, "Unable to handle the session name"
 
         self.versions = []
-        version_files = self._get_ftp_files(self._ftp_root, 'bills/{}/billtext/html'.format(session))
+        version_files = self._get_ftp_files(self._FTP_ROOT,
+                                            'bills/{}/billtext/html'.
+                                            format(session_code))
         for item in version_files:
             bill_id = item.split('/')[-1].split('.')[0]
-            bill_id = ' '.join(re.search(r'([A-Z]{2})R?0+(\d+)', bill_id).groups())
+            bill_id = ' '.join(re.search(r'([A-Z]{2})R?0+(\d+)',
+                               bill_id).groups())
             self.versions.append((bill_id, item))
 
-        for bill_type in ['bills', 'concurrent_resolutions',
-                          'joint_resolutions', 'resolutions']:
-            # This is the billhistory directory for a particular type of bill
-            # (e.g. senate resolutions).  It should contain subdirectories
-            # with names like "SR00001_SR00099".
-            history_dir_url = 'ftp://' + self._ftp_root + '/bills/%s/billhistory/%s_%s/' % (
-                    session, chamber_name(chamber), bill_type)
-            history_groups_listing = self.urlopen(history_dir_url)
-            # A group_dir has a name like "HJR00200_HJR00299" and contains
-            # the files for a group of 100 bills.
-            for group_dir in parse_ftp_listing(history_groups_listing):
-                self.scrape_group(
-                    chamber, session, history_dir_url, group_dir)
+        history_files = self._get_ftp_files(self._FTP_ROOT,
+                                            'bills/{}/billhistory'.
+                                            format(session_code))
+        for bill_url in history_files:
+            self.scrape_bill(session, bill_url)
 
-    def scrape_group(self, chamber, session, history_dir_url, group_dir):
-        """Scrapes information on all bills in a given group of 100 bills."""
-        # Under billhistory, each group dir has a name like HBnnnnn_HBnnnnn,
-        # HCRnnnnn_HCRnnnnn, HJRnnnnn_HJRnnnnn, HRnnnnn_HRnnnnn.
-        history_group_url = urljoin(history_dir_url, group_dir) + '/'
-        # For each group_dir under billhistory, there is a corresponding dir in
-        # billtext/html containing the bill versions (texts).  These dirs have
-        # similar names, except the prefix is "HC", "HJ", "SC", "SJ" for
-        # concurrent/joint resolutions instead of "HCR", "HJR", "SCR", "SJR".
-
-        # Now get the history and version data for each bill.
-        histories_list = self.urlopen(history_group_url)
-        for history_file in parse_ftp_listing(histories_list):
-            url = urljoin(history_group_url, history_file)
-            bill_num = int(re.search(r'\d+', history_file).group(0))
-            self.scrape_bill(chamber, session, url, history_group_url,
-                             bill_num)
-
-    def scrape_bill(self, chamber, session, history_url, history_group_url,
-                   billno):
-        """Scrapes the information for a single bill."""
-        history_xml = self.urlopen(history_url)
-        if "Bill does not exist." in history_xml:
+    def scrape_bill(self, session, history_url):
+        history_xml = self.urlopen(history_url).encode('ascii', 'ignore')
+        try:
+            root = etree.fromstring(history_xml)
+        except:
+            self.warning("File {} is likely not a bill history".
+                         format(history_url))
             return
 
-        bill = self.parse_bill_xml(chamber, session, history_xml)
-        if bill is None:
-            return
-
-        bill.add_source(history_url)
-
-        text_group_url = history_group_url.replace(
-            '/billhistory/', '/billtext/html/')
-        text_group_url = re.sub('([HS][CJ])R', '\\1', text_group_url)
-
-        self.save_bill(bill)
-
-    def parse_bill_xml(self, chamber, session, txt):
-        root = lxml.etree.fromstring(txt.bytes)
-        bill_id = ' '.join(root.attrib['bill'].split(' ')[1:])
         bill_title = root.findtext("caption")
-        if bill_title is None:
-            return None
+        if (bill_title is None or
+                "Bill does not exist" in history_xml):
+            return
+        bill_id = ' '.join(root.attrib['bill'].split(' ')[1:])
 
-        if session[2] == 'R':
-            session = session[0:2]
+        chamber = self.CHAMBERS[bill_id[0]]
 
         if bill_id[1] == 'B':
             bill_type = ['bill']
@@ -127,21 +98,21 @@ class TXBillScraper(BillScraper):
         versions = [x for x in self.versions if x[0] == bill_id]
         for version in versions:
             version_names = {
-                    'I': 'Introduced',
-                    'E': 'Engrossed',
-                    'S': 'Senate Committee Report',
-                    'H': 'House Committee Report',
-                    'F': 'Enrolled'
+                'I': 'Introduced',
+                'E': 'Engrossed',
+                'S': 'Senate Committee Report',
+                'H': 'House Committee Report',
+                'F': 'Enrolled'
             }
             bill.add_version(
-                    name=version_names[version[1][-5]],
-                    url=version[1],
-                    mimetype='text/html'
+                name=version_names[version[1][-5]],
+                url=version[1],
+                mimetype='text/html'
             )
 
         for action in root.findall('actions/action'):
             act_date = datetime.datetime.strptime(action.findtext('date'),
-                                            "%m/%d/%Y").date()
+                                                  "%m/%d/%Y").date()
 
             extra = {}
             extra['action_number'] = action.find('actionNumber').text
@@ -192,7 +163,8 @@ class TXBillScraper(BillScraper):
                     atype.append('bill:introduced')
             elif desc == "Passed as amended":
                 atype = 'bill:passed'
-            elif desc.startswith('Referred to') or desc.startswith("Recommended to be sent to "):
+            elif (desc.startswith('Referred to') or
+                    desc.startswith("Recommended to be sent to ")):
                 atype = 'committee:referred'
             elif desc == "Reported favorably w/o amendment(s)":
                 atype = 'committee:passed'
@@ -225,16 +197,22 @@ class TXBillScraper(BillScraper):
                 bill.add_sponsor('primary', author, official_type='author')
         for coauthor in root.findtext('coauthors').split(' | '):
             if coauthor != "":
-                bill.add_sponsor('cosponsor', coauthor, official_type='coauthor')
+                bill.add_sponsor('cosponsor',
+                                 coauthor,
+                                 official_type='coauthor')
         for sponsor in root.findtext('sponsors').split(' | '):
             if sponsor != "":
                 bill.add_sponsor('primary', sponsor, official_type='sponsor')
         for cosponsor in root.findtext('cosponsors').split(' | '):
             if cosponsor != "":
-                bill.add_sponsor('cosponsor', cosponsor, official_type='cosponsor')
+                bill.add_sponsor('cosponsor',
+                                 cosponsor,
+                                 official_type='cosponsor')
 
         bill['subjects'] = []
         for subject in root.iterfind('subjects/subject'):
             bill['subjects'].append(subject.text.strip())
 
-        return bill
+        bill.add_source(history_url)
+
+        self.save_bill(bill)


### PR DESCRIPTION
Made an easy enhancement to grab all the other documents available for a bill. PR-review this _after_ #599, since this builds on the FTP crawling developed therein.