### PR TITLE
TX: Fix chamber mis-assignment

### DIFF
--- a/openstates/tx/bills.py
+++ b/openstates/tx/bills.py
@@ -11,7 +11,7 @@ from billy.scrape.bills import BillScraper, Bill
 class TXBillScraper(BillScraper):
     jurisdiction = 'tx'
     _FTP_ROOT = 'ftp.legis.state.tx.us'
-    CHAMBERS = {'H': 'lower', 'S': 'lower'}
+    CHAMBERS = {'H': 'lower', 'S': 'upper'}
     NAME_SLUGS = {
         'I': 'Introduced',
         'E': 'Engrossed',


### PR DESCRIPTION
Let's throw out all 84th-session `bill`s from the database, and then a fixed run will pull them all back in.