### PR TITLE
OH: Default action categorize to 'other'

### DIFF
--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -164,8 +164,9 @@ class OHBillScraper(BillScraper):
                                     try:
                                         action_type = action_dict[action["actioncode"]]
                                     except KeyError:
-                                        raise AssertionError("Unknown action {desc} with code {code}. Add it to the action_dict.".format(desc=action_desc, code=action["actioncode"]))
-                                        
+                                        self.warning("Unknown action {desc} with code {code}. Add it to the action_dict.".format(desc=action_desc, code=action["actioncode"]))
+                                        action_type = "other"
+
 
                                     date = datetime.datetime.strptime(action["datetime"],"%Y-%m-%dT%H:%M:%S")
 


### PR DESCRIPTION
I'm unhappy about doing this, but over the last few days we've seen multiple new action codes per day, which has prevented _any_ of our builds from working, even if I add and rerun within a single day.