### PR TITLE
OH: Tweak subcommittee name

### DIFF
--- a/openstates/oh/legislators.py
+++ b/openstates/oh/legislators.py
@@ -17,7 +17,7 @@ SUBCOMMITTEES = {
     "Finance - Corrections Subcommittee": "Finance",
     "Finance - Education Subcommittee": "Finance",
     "Finance - General Government Subcommittee": "Finance",
-    "Finance - Higher Ed  Subcommittee": "Finance",
+    "Finance - Higher Ed Subcommittee": "Finance",
     "Finance - Workforce Subcommittee": "Finance",
 
     # The House has mostly Finance, but also one more


### PR DESCRIPTION
I think this is all there is to the fix, but as of now the Ohio House website is completely down. So wait until that's back up and test the `legislator` scraper before pulling this change in.