### PR TITLE
UT: Skip votes if their webpage returns a 404 error

### DIFF
--- a/openstates/ut/bills.py
+++ b/openstates/ut/bills.py
@@ -277,7 +277,12 @@ class UTBillScraper(BillScraper, LXMLMixin):
         bill.add_vote(vote)
 
     def parse_html_vote(self, bill, actor, date, motion, url, uniqid):
-        page = self.urlopen(url)
+        try:
+            page = self.urlopen(url)
+        except scrapelib.HTTPError:
+            self.warning("A vote page not found for bill {}".
+                         format(bill['bill_id']))
+            return
         page = lxml.html.fromstring(page)
         page.make_links_absolute(url)
         descr = page.xpath("//b")[0].text_content()

--- a/openstates/ut/bills.py
+++ b/openstates/ut/bills.py
@@ -214,7 +214,7 @@ class UTBillScraper(BillScraper, LXMLMixin):
                                     vote_url, uniqid)
 
     def scrape_committee_vote(self, bill, actor, date, motion, url, uniqid):
-        page = self.urlopen(url)
+        page = self.get(url).text
         page = lxml.html.fromstring(page)
         page.make_links_absolute(url)
         committee = page.xpath("//b")[0].text_content()
@@ -278,7 +278,7 @@ class UTBillScraper(BillScraper, LXMLMixin):
 
     def parse_html_vote(self, bill, actor, date, motion, url, uniqid):
         try:
-            page = self.urlopen(url)
+            page = self.get(url).text
         except scrapelib.HTTPError:
             self.warning("A vote page not found for bill {}".
                          format(bill['bill_id']))
@@ -347,7 +347,7 @@ class UTBillScraper(BillScraper, LXMLMixin):
         bill.add_vote(vote)
 
     def parse_vote(self, bill, actor, date, motion, url, uniqid):
-        page = self.urlopen(url)
+        page = self.get(url).text
         bill.add_source(url)
         vote_re = re.compile('YEAS -?\s?(\d+)(.*)NAYS -?\s?(\d+)'
                              '(.*)ABSENT( OR NOT VOTING)? -?\s?'

--- a/openstates/ut/legislators.py
+++ b/openstates/ut/legislators.py
@@ -16,7 +16,7 @@ class UTLegislatorScraper(LegislatorScraper):
 
     def scrape_lower(self, term):
         url = 'http://le.utah.gov/house2/representatives.jsp'
-        html = self.urlopen(url)
+        html = self.get(url).text
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)
 
@@ -40,7 +40,7 @@ class UTLegislatorScraper(LegislatorScraper):
                 raise ValueError('unknown party')
 
             # get photo
-            leg_html = self.urlopen(leg_url)
+            leg_html = self.get(leg_url).text
             leg_doc = lxml.html.fromstring(leg_html)
             leg_doc.make_links_absolute(leg_url)
             photo_url = leg_doc.xpath('//img[@alt="photo"]/@src')[0]
@@ -65,7 +65,7 @@ class UTLegislatorScraper(LegislatorScraper):
 
     def scrape_upper(self, term):
         url = 'http://www.utahsenate.org/aspx/roster.aspx'
-        html = self.urlopen(url)
+        html = self.get(url).text
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)
 
@@ -107,7 +107,7 @@ class UTLegislatorScraper(LegislatorScraper):
 
             # get photo
             try:
-                leg_html = self.urlopen(leg_url)
+                leg_html = self.get(leg_url).text
                 leg_doc = lxml.html.fromstring(leg_html)
                 leg_doc.make_links_absolute(leg_url)
                 photo_url = leg_doc.xpath('//p[@class="photo"]/img/@src')[0]


### PR DESCRIPTION
This seems to be a fix for a one-off issue, where [SB 235](http://le.utah.gov/~2015/bills/static/SB0235.html) had a duplicate vote listed in its actions. The first of these had a [valid link to the vote](http://le.utah.gov/DynaBill/svotes.jsp?sessionid=2015GS&voteid=1765&house=S), and the second one had a [dead link](http://le.utah.gov/~2015/status/sbillsta/0). Included a `self.warning()` so that this doesn't proliferate without explicitly notifying us.