### PR TITLE
FL: Increase precision of allowed vote codes for Senate committee rolls

### DIFF
--- a/openstates/fl/bills.py
+++ b/openstates/fl/bills.py
@@ -229,7 +229,7 @@ class FLBillScraper(BillScraper, LXMLMixin):
                         ''', line).group(1)
                 # Usually non-voting members won't even have a code listed
                 did_vote = bool(
-                    re.search(r'^\s+([A-Z\-]+)\s+[A-Z][a-z]', line))
+                    re.search(r'^\s+(X|VA)\s+[A-Z][a-z]', line))
                 if did_vote:
                     # Check where the "X" or vote code is on the page
                     vote_column = len(line) - len(line.lstrip())


### PR DESCRIPTION
This only allows "X" (standard vote) and "VA" (vote after roll call) as valid votes; it omits "AV" (abstained from voting) and other codes. The code _does_ confirm that the totals match the head counts, so after a full run I'm confident this change is correct.