### PR TITLE
WV: workaround for missing bill titles

### DIFF
--- a/openstates/wv/bills.py
+++ b/openstates/wv/bills.py
@@ -60,6 +60,8 @@ class WVBillScraper(BillScraper):
         for link in page.xpath("//a[contains(@href, 'Bills_history')]"):
             bill_id = link.xpath("string()").strip()
             title = link.xpath("string(../../td[2])").strip()
+            if not title:
+                title = bill_id
             self.scrape_bill(session, chamber, bill_id, title,
                              link.attrib['href'])
 
@@ -73,6 +75,8 @@ class WVBillScraper(BillScraper):
         for link in doc.xpath('//a[contains(@href, "houseorig=%s")]' % orig):
             bill_id = link.xpath("string()").strip()
             title = link.xpath("string(../../td[2])").strip()
+            if not title:
+                title = bill_id
             self.scrape_bill(session, chamber, bill_id, title,
                              link.attrib['href'])
 

--- a/openstates/wv/bills.py
+++ b/openstates/wv/bills.py
@@ -61,6 +61,7 @@ class WVBillScraper(BillScraper):
             bill_id = link.xpath("string()").strip()
             title = link.xpath("string(../../td[2])").strip()
             if not title:
+                self.logger.warning("Can't find bill title, using ID as title")
                 title = bill_id
             self.scrape_bill(session, chamber, bill_id, title,
                              link.attrib['href'])
@@ -76,6 +77,7 @@ class WVBillScraper(BillScraper):
             bill_id = link.xpath("string()").strip()
             title = link.xpath("string(../../td[2])").strip()
             if not title:
+                self.logger.warning("Can't find bill title, using ID as title")
                 title = bill_id
             self.scrape_bill(session, chamber, bill_id, title,
                              link.attrib['href'])


### PR DESCRIPTION
For one bill there seems to be no title anywhere (although all other information incl bill text is good and valid) so I'm just using the ID as the title in this case. @paultag, is this OK? Super non-urgent.