### PR TITLE
DC: correct actor when mayor or committee withdraws a bill

### DIFF
--- a/openstates/dc/bills.py
+++ b/openstates/dc/bills.py
@@ -119,9 +119,21 @@ class DCBillScraper(BillScraper):
                 if "WithDrawnDate" in legislation_info:
                     withdrawn_date = self.date_format(legislation_info["WithDrawnDate"])
                     withdrawn_by = legislation_info["WithdrawnBy"][0]["Name"].strip()
+                    if withdrawn_by == "the Mayor":
 
+                        bill.add_action("executive",
+                                    "withdrawn",
+                                    withdrawn_date,
+                                    "bill:withdrawn")
 
-                    bill.add_action("upper",
+                    elif "committee" in withdrawn_by.lower():
+                        bill.add_action("upper",
+                                    "withdrawn",
+                                    withdrawn_date,
+                                    "bill:withdrawn",
+                                    committees=withdrawn_by)
+                    else:
+                        bill.add_action("upper",
                                     "withdrawn",
                                     withdrawn_date,
                                     "bill:withdrawn",


### PR DESCRIPTION
this doesn't fix the University of District of Columbia as a legislator who withdraws a bill - the only way I can think of to do that is to hard-code them in. @paultag how big a deal is it if we have them as a (unresolved) related_entity of type legislator in one bill?