### PR TITLE
CO: fix misparsing of house votes on senate bills

### DIFF
--- a/openstates/co/votes.py
+++ b/openstates/co/votes.py
@@ -69,7 +69,7 @@ class COVoteScraper(VoteScraper, LXMLMixin):
                         continue
 
                 found = re.findall(
-                    "(?P<bill_id>(H|S|SJ|HJ)(B|M|R)\d{2}-\d{4})",
+                    "(?P<bill_id>(H|S|SJ|HJ)(B|M|R)\d{2}-\d{3,4})",
                     line
                 )
                 if found != []:


### PR DESCRIPTION
we were not detecting senate bills as new bills. now we are.

doing some research into whether we'll need to hand-delete the bad bills.