### PR TITLE
NM: allowed for capitol phone if no office phone

### DIFF
--- a/openstates/nm/legislators.py
+++ b/openstates/nm/legislators.py
@@ -44,7 +44,7 @@ class NMLegislatorScraper(LegislatorScraper):
             # decline to state = independent
             party = 'Independent'
         else:
-            raise Exception("unknown party encountered")
+            raise AssertionError("unknown party encountered")
 
         photo_url = doc.xpath('//img[@id="ctl00_mainCopy_formViewLegislator_imgLegislator"]/@src')[0]
 
@@ -52,10 +52,10 @@ class NMLegislatorScraper(LegislatorScraper):
         if email:
             email = email[0]
         else:
-            print "no email"
+            self.warning('no email')
             email = None
 
-        district_address = ", ".join(doc.xpath(xpath.format('lblAddress')))
+        district_address = "\n".join(doc.xpath(xpath.format('lblAddress')))
 
         district_phone = doc.xpath(xpath.format('lblHomePhone'))
         # if they don't have a home phone, check for an office phone
@@ -68,10 +68,10 @@ class NMLegislatorScraper(LegislatorScraper):
 
         capitol_address = doc.xpath(xpath.format('lblCapitolRoom'))
         if capitol_address:
-            capitol_address = 'Room ' + capitol_address[0] + ' State Capitol, Santa Fe, NM 87501'
+            capitol_address = 'Room ' + capitol_address[0] + ' State Capitol\nSanta Fe, NM 87501'
         else:
             capitol_address = None
-        
+
         capitol_phone = doc.xpath(xpath.format('lblCapitolPhone'))
         if capitol_phone:
             capitol_phone = "(505) " + capitol_phone[0]
@@ -95,12 +95,10 @@ class NMLegislatorScraper(LegislatorScraper):
                 role = 'interim ' + role.lower()
             else:
                 role = role.lower()
+            if ' Committee' in committee:
+                committee = committee.replace(" Committee", '')
+            if ' Subcommittee' in committee:
+                committee = committee.replace(' Subcommittee', '')
             leg.add_role('committee member', term, committee=committee, position=role, chamber=chamber)
-
-        # Already have the photo url.
-        try:
-            del leg['image_url']
-        except KeyError:
-            pass
 
         self.save_legislator(leg)

--- a/openstates/nm/legislators.py
+++ b/openstates/nm/legislators.py
@@ -61,18 +61,19 @@ class NMLegislatorScraper(LegislatorScraper):
                     pass
                 if val:
                     properties[key] = val.strip()
-                else:
-                    properties[key] = None
 
             if found is False and key not in optional:
                 self.warning('bad legislator page %s missing %s' %
                              (url, id_))
                 return
+            elif found is False:
+                properties[key] = None
+            elif properties[key] == ["lblCapitolPhone", "lblOfficePhone"]:
+                properties[key] = None
 
         # image & email are a bit different
         properties['photo_url'] = doc.xpath('//img[@id="ctl00_mainCopy_formViewLegislator_imgLegislator"]/@src')[0]
         email = doc.get_element_by_id('ctl00_mainCopy_formViewLegislator_linkEmail').text
-        
 
         properties['url'] = url
 

--- a/openstates/nm/legislators.py
+++ b/openstates/nm/legislators.py
@@ -28,61 +28,7 @@ class NMLegislatorScraper(LegislatorScraper):
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)
 
-<<<<<<< HEAD
         xpath = '//span[@id="ctl00_mainCopy_formViewLegislator_{}"]/text()'
-=======
-        # most properties are easy to pull
-        optional = ["home_phone"]
-        properties = {
-            'start_year': 'lblStartYear',
-            'district': "linkDistrict",
-            'occupation': "lblOccupation",
-            'header': "lblHeader",
-            'addr_street': "lblAddress",
-            'office_phone': ["lblCapitolPhone", "lblOfficePhone"],
-            'home_phone': "lblHomePhone",
-#            '': "",
-#            '': "",
-#            '': "",
-#            '': "",
-            }
-
-        for key, value in properties.iteritems():
-            if isinstance(value, list):
-                values = value
-            else:
-                values = [value]
-
-            found = False
-            for value in values:
-                id_ = 'ctl00_mainCopy_formViewLegislator_%s' % value
-                val = None
-                try:
-                    val = "\n".join(doc.get_element_by_id(id_).itertext())
-                    found = True
-                except KeyError:
-                    pass
-                if val:
-                    properties[key] = val.strip()
-
-            if found is False and key not in optional:
-                self.warning('bad legislator page %s missing %s' %
-                             (url, id_))
-                return
-            elif found is False:
-                properties[key] = None
-            elif properties[key] == ["lblCapitolPhone", "lblOfficePhone"]:
-                properties[key] = None
-
-        # image & email are a bit different
-        properties['photo_url'] = doc.xpath('//img[@id="ctl00_mainCopy_formViewLegislator_imgLegislator"]/@src')[0]
-        email = doc.get_element_by_id('ctl00_mainCopy_formViewLegislator_linkEmail').text
-
-        properties['url'] = url
-
-        properties['chamber'] = chamber
-        properties['term'] = term
->>>>>>> a2bb5ea5c2ffb0014f00414e82ecc3c934da744e
 
         district = doc.xpath('//a[@id="ctl00_mainCopy_formViewLegislator_linkDistrict"]/text()')[0]
 

--- a/openstates/nm/legislators.py
+++ b/openstates/nm/legislators.py
@@ -28,102 +28,74 @@ class NMLegislatorScraper(LegislatorScraper):
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)
 
-        # most properties are easy to pull
-        optional = ["home_phone"]
-        properties = {
-            'start_year': 'lblStartYear',
-            'district': "linkDistrict",
-            'occupation': "lblOccupation",
-            'header': "lblHeader",
-            'addr_street': "lblAddress",
-            'office_phone': ["lblCapitolPhone", "lblOfficePhone"],
-            'home_phone': "lblHomePhone",
-#            '': "",
-#            '': "",
-#            '': "",
-#            '': "",
-            }
+        xpath = '//span[@id="ctl00_mainCopy_formViewLegislator_{}"]/text()'
 
-        for key, value in properties.iteritems():
-            if isinstance(value, list):
-                values = value
-            else:
-                values = [value]
+        district = doc.xpath('//a[@id="ctl00_mainCopy_formViewLegislator_linkDistrict"]/text()')[0]
 
-            found = False
-            for value in values:
-                id_ = 'ctl00_mainCopy_formViewLegislator_%s' % value
-                val = None
-                try:
-                    val = "\n".join(doc.get_element_by_id(id_).itertext())
-                    found = True
-                except KeyError:
-                    pass
-                if val:
-                    properties[key] = val.strip()
+        header = doc.xpath(xpath.format('lblHeader'))
+        full_name, party = header[0].rsplit("-", 1)
+        full_name = full_name.replace("Representative","").replace("Senator","").strip()
 
-            if found is False and key not in optional:
-                self.warning('bad legislator page %s missing %s' %
-                             (url, id_))
-                return
-            elif found is False:
-                properties[key] = None
-            elif properties[key] == ["lblCapitolPhone", "lblOfficePhone"]:
-                properties[key] = None
-
-        # image & email are a bit different
-        properties['photo_url'] = doc.xpath('//img[@id="ctl00_mainCopy_formViewLegislator_imgLegislator"]/@src')[0]
-        email = doc.get_element_by_id('ctl00_mainCopy_formViewLegislator_linkEmail').text
-
-        properties['url'] = url
-
-        properties['chamber'] = chamber
-        properties['term'] = term
-
-        full_name, party = properties['header'].rsplit("-", 1)
-
-        properties['full_name'] = full_name.replace("Representative","").replace("Senator","").strip()
-        properties['party'] = party
-
-        if '(D)' in properties['party']:
-            properties['party'] = 'Democratic'
-        elif '(R)' in properties['party']:
-            properties['party'] = 'Republican'
-        elif '(DTS)' in properties['party']:
+        if '(D)' in party:
+            party = 'Democratic'
+        elif '(R)' in party:
+            party = 'Republican'
+        elif '(DTS)' in party:
             # decline to state = independent
-            properties['party'] = 'Independent'
+            party = 'Independent'
         else:
             raise Exception("unknown party encountered")
 
-        address = properties.pop('addr_street')
+        photo_url = doc.xpath('//img[@id="ctl00_mainCopy_formViewLegislator_imgLegislator"]/@src')[0]
 
-        phone = (properties.pop('office_phone') or
-                 properties.pop('home_phone'))
-
-        leg = Legislator(**properties)
-        leg.add_source(url)
-
+        email = doc.xpath('//a[@id="ctl00_mainCopy_formViewLegislator_linkEmail"]/text()')
         if email:
-            properties['email'] = email.strip()
+            email = email[0]
         else:
             print "no email"
             email = None
 
-        leg.add_office('district', 'District Address', address=address,
-                       phone=phone, email=email)
+        district_address = ", ".join(doc.xpath(xpath.format('lblAddress')))
+
+        district_phone = doc.xpath(xpath.format('lblHomePhone'))
+        # if they don't have a home phone, check for an office phone
+        if not district_phone:
+            district_phone = doc.xpath(xpath.format('lblOfficePhone'))
+        if district_phone:
+            district_phone = district_phone[0]
+        else:
+            district_phone = None
+
+        capitol_address = doc.xpath(xpath.format('lblCapitolRoom'))
+        if capitol_address:
+            capitol_address = 'Room ' + capitol_address[0] + ' State Capitol, Santa Fe, NM 87501'
+        else:
+            capitol_address = None
+        
+        capitol_phone = doc.xpath(xpath.format('lblCapitolPhone'))
+        if capitol_phone:
+            capitol_phone = "(505) " + capitol_phone[0]
+        else:
+            capitol_phone = None
+
+        leg = Legislator(term=term, chamber=chamber, district=district, full_name=full_name, party=party, photo_url=photo_url)
+        leg.add_source(url)
+
+        leg.add_office('district', 'District Office', address=district_address,
+                        phone=district_phone)
+        leg.add_office('capitol', 'Capitol Office', address=capitol_address,
+                        phone=capitol_phone, email=email)
 
         # committees
         # skip first header row
         for row in doc.xpath('//table[@id="ctl00_mainCopy_gridViewCommittees"]/tr')[1:]:
-            role, committee, note = [x.text_content()
-                                     for x in row.xpath('td')]
+            role, committee, note = [x.text_content() for x in row.xpath('td')]
             committee = committee.title()
             if 'Interim' in note:
                 role = 'interim ' + role.lower()
             else:
                 role = role.lower()
-            leg.add_role('committee member', term, committee=committee,
-                          position=role, chamber=chamber)
+            leg.add_role('committee member', term, committee=committee, position=role, chamber=chamber)
 
         # Already have the photo url.
         try:


### PR DESCRIPTION
So, couple of questions:
1- do we care about adding area code to phone numbers? (Capital phones are only 7 digits long)
2- Is there a reason that home phone is in 'optional' as well as 'properties'?

![screen shot 2015-07-28 at 11 18 36 am](https://cloud.githubusercontent.com/assets/8128188/8935378/6bce4356-351a-11e5-947c-f24b98fb2261.png)

if not is there a reason to keep this:
if found is False and key not in optional:
                 self.warning('bad legislator page %s missing %s' %
                              (url, id_))
                 return
 