### PR TITLE
WI: Remove SSL to avoid error

### DIFF
--- a/openstates/wi/bills.py
+++ b/openstates/wi/bills.py
@@ -42,7 +42,7 @@ class WIBillScraper(BillScraper):
 
     def scrape_subjects(self, year, site_id):
         last_url = None
-        next_url = 'https://docs.legis.wisconsin.gov/%s/related/subject_index/index/' % year
+        next_url = 'http://docs.legis.wisconsin.gov/%s/related/subject_index/index/' % year
 
         # if you visit this page in your browser it is infinite-scrolled
         # but if you disable javascript you'll see the 'Down' links


### PR DESCRIPTION
We've been seeing a production bug involving the SSL for bill-subject HTTPS requests, so I'm just switching to HTTP. Confirmed working locally to the same effect.