### PR TITLE
Improve docker stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN echo mysql-server mysql-server/root_password_again password nicetry | debcon
 # CA requires MySQL (python-dev, mysql-server, libmysqlclient-dev)
 # NM and NJ require mdbtools
 # KS requires Abiword
-RUN apt-get update && apt-get install -y \
+RUN apt-get clean && apt-get update && apt-get upgrade && apt-get install -y \
     poppler-utils \
     s3cmd \
     mongodb-clients \


### PR DESCRIPTION
Following [some advice](https://serverfault.com/questions/690639/api-get-error-reading-from-server-under-docker) to avoid the errors Docker Hub hit in the past couple builds.