### PR TITLE
Fix MT email regex

### DIFF
--- a/openstates/mt/legislators.py
+++ b/openstates/mt/legislators.py
@@ -235,7 +235,7 @@ class MTLegislatorScraper(LegislatorScraper):
         else:
             if email:
                 html = lxml.html.tostring(email.getparent())
-                match = re.search('\w+@\w+\.[a-z]+', html)
+                match = re.search('[a-zA-Z0-9\.\_\%\+\-]+@\w+\.[a-z]+', html)
                 if match:
                     details['email'] = match.group()
 


### PR DESCRIPTION
The Montana scraper was running emails through a regex that stripped out the first part of many legislator email addresses. This slightly more permissive regex should fix that.

The old regex truncated emails like Sen.Bradley.Hamlett@mt.gov to Hamlett@mt.gov. This patch correctly parses these emails.