### PR TITLE
Add Louisiana 2016 Regular Session to scraper

### DIFF
--- a/openstates/la/__init__.py
+++ b/openstates/la/__init__.py
@@ -29,7 +29,15 @@ metadata = {
                 "2014",
                 "2015",
             ]
-        }
+        },
+        {
+            "name": "2016-2019",
+            "start_year": 2016,
+            "end_year": 2019,
+            "sessions": [
+                "2016"
+            ]
+        }        
     ],
     "name": "Louisiana",
     "legislature_url": "http://www.legis.la.gov/",
@@ -80,6 +88,11 @@ metadata = {
             'display_name': '2015 Regular Session',
             '_scraped_name': '2015 Regular Session',
         },
+        "2016": {
+            "type": "primary",
+            'display_name': '2016 Regular Session',
+            '_scraped_name': '2016 Regular Session',
+        },        
     },
     "legislature_name": "Louisiana Legislature",
     'chambers': {


### PR DESCRIPTION
Louisiana recently added a 2016 session, and scraper was failing with a missing session error.

I've tried adding it myself, it seems to be working now, but this is my first time trying to contribute to this project, so please let me know if I've done anything wrong.