### PR TITLE
IN: skip missing bill verisons for links that are 500'ing

### DIFF
--- a/openstates/in/bills.py
+++ b/openstates/in/bills.py
@@ -389,11 +389,16 @@ class INBillScraper(BillScraper):
             
             #versions and votes
             for version in bill_json["versions"][::-1]:
-                version_json = client.get("bill_version",
+                try:
+                    version_json = client.get("bill_version",
                                         session=session,
                                         bill_id=version["billName"],
                                         version_id=version["printVersionName"])
 
+                except scrapelib.HTTPError:
+                    self.logger.warning("Bill version does not seem to exist.")
+                    continue
+                
                 self.deal_with_version(version_json,bill,proxy)
 
 


### PR DESCRIPTION
these bill versions don't seem to exist properly in the JSON. The bill I checked has at least 1 working version - my suspicion is that when they flipped the site to the new version in 2015 they only kept the most recent version of some older bill text but irritatingly left the others in the JSON. I'm just skipping the bad versions, there's not much else to be done.

This is super slow, probably because it tries to hit the 500'ing page multiple times with ever-increasing timeouts (that is in place because of other issues we've seen in IN). Presumably that's not a big deal because this only needs to run once to pick up all the historical bills so it doesn't matter if it takes 4 days (also not unheard of in IN...) but if it ends up implicating the new session, that probably needs to be fixed.

I didn't run it all the way through on my local due to slowness but did confirm that it gets past the situation noted by @dmc2015 