### PR TITLE
Fill in 'No Address Found' for one missing address to allow rest of scrapers to run.

### DIFF
--- a/openstates/ri/legislators.py
+++ b/openstates/ri/legislators.py
@@ -124,6 +124,9 @@ class RILegislatorScraper(LegislatorScraper, LXMLMixin):
             if homepage_url is not None:
                 kwargs['url'] = homepage_url
 
+            if d['address'] is '':
+                d['address'] = 'No Address Found'
+
             leg = Legislator(term, chamber, district_name, full_name,
                              '', '', '',
                              translate[d['party']],


### PR DESCRIPTION
Sen John A. Pagliarini is missing a District Office Address.