### PR TITLE
skip text versions that have - COPY in name

### DIFF
--- a/openstates/nm/bills.py
+++ b/openstates/nm/bills.py
@@ -415,6 +415,10 @@ class NMBillScraper(BillScraper):
 
         # all links but first one
         for fname in doc.xpath('//a/text()')[1:]:
+            # if a COPY continue 
+            if re.search('- COPY', fname):
+                continue 
+
             # Delete any errant words found following the file name
             fname = fname.split(" ")[0]
 


### PR DESCRIPTION
HB0055 has copy versions (http://www.nmlegis.gov/Sessions/16%20Regular/bills/house/), which was breaking the scraper.