### PR TITLE
fixing issue with scraper for anything outside of a normal session

### DIFF
--- a/openstates/la/bills.py
+++ b/openstates/la/bills.py
@@ -239,6 +239,12 @@ class LABillScraper(BillScraper, LXMLMixin):
             date, chamber, page, text = [x.text for x in action.xpath(".//td")]
             date += "/%s" % (session)  # Session is April --> June. Prefiles
             # look like they're in January at earliest.
+
+            #required to remove the special session extended name, this will remove any characters, including and following a space
+            if (re.search('\s(.*)', date) is not None):
+                m = re.search('\s(.*)', date)
+                date = date[:m.start()]
+
             date = dt.datetime.strptime(date, "%m/%d/%Y")
             chamber = {"S": "upper", "H": "lower", "J": 'joint'}[chamber]
 


### PR DESCRIPTION
Pretty concerned the init for la. 
Dates are missing from the session or are incorrect, I am wondering how this was working previously.
When no date is set it, ’start_date’ - ‘end_date’, it seems to be pulling 2016 data. On my local version each session has 28 bills.

![image](https://cloud.githubusercontent.com/assets/7463796/12553419/542e6000-c345-11e5-9a79-415d3fa238ae.png)


I am fairly sure the 2011 Special session fix is good though.

Regarding the other session specific scrapes:
We are going to a URL for scraping and it is stuck on 2016, it doesn’t change based on session selected. I am guessing the production environment already has historical data scraped prior to them changing the URL on the site to being specific to 2016. So this secondary issue is only impacting local versions of OpenStates.

On line 15 of la/bills.py a URL var is set, "http://www.legis.la.gov/Legis/BillSearchListQ.aspx?r=%s1*" . On line 44 we format the string and it goes here

http://www.legis.la.gov/Legis/BillSearchListQ.aspx?r=SB1*
or 
http://www.legis.la.gov/Legis/BillSearchListQ.aspx?r=HB1*

That link is always 2016. It is not directly related to my fix but we should keep it in mind and never remove the la collection. I also I want to make sure that the issue can be replicated.


