### PR TITLE
WA: Removed patch for wrong bill data.

### DIFF
--- a/openstates/wa/bills.py
+++ b/openstates/wa/bills.py
@@ -367,13 +367,6 @@ class WABillScraper(BillScraper, LXMLMixin):
                     if 'scheduled for' in action['action'].lower():
                         continue
 
-                    # temporary fix for SB 5255 b/c of wrong date
-                    if bill['bill_id'] == 'SB 5255' and\
-                        action['action'] == 'Placed on second reading.':
-                        action['date'] = datetime.datetime(
-                            year=2015, month=date.month, day=date.day)
-                        continue 
-
                     msg = 'Found an action date that was in the future.'
                     raise Exception(msg)
 


### PR DESCRIPTION
The Washington Legislative Information Center has fixed this issue upstream, so the patch is no longer necessary.