### PR TITLE
Move AL 2016 session identifier so it becomes default AL session

### DIFF
--- a/openstates/al/__init__.py
+++ b/openstates/al/__init__.py
@@ -21,7 +21,7 @@ metadata =  {
          'end_year': 2014,
         },
         {'name': '2015-2018',
-         'sessions': ['2016rs', '2015os','2015rs', 'First Special Session 2015', 'Second Special Session 2015'],
+         'sessions': ['2015os','2015rs', 'First Special Session 2015', 'Second Special Session 2015', '2016rs'],
          'start_year': 2015,
          'end_year': 2018,
         }


### PR DESCRIPTION
By the current code if you do a 'billy-update al bills' it tries to pull from the 2015 second special session, because that's the last session identifier in the code. 

The 2016 Regular Session is live, so we need to move that identifier to last so that becomes the default if you don't specify a session.