### PR TITLE
OH: Generate legislators' email addresses

### DIFF
--- a/openstates/oh/legislators.py
+++ b/openstates/oh/legislators.py
@@ -159,7 +159,7 @@ class OHLegislatorScraper(LegislatorScraper):
                 if chamber == 'lower' else \
                 'sd{0:0{width}}@ohiosenate.gov'
             ).format(int(district), width=2)
-            print email
+
             leg = Legislator(term, chamber, district, full_name,
                              party=party, url=homepage, photo_url=img)
 

--- a/openstates/oh/legislators.py
+++ b/openstates/oh/legislators.py
@@ -154,12 +154,19 @@ class OHLegislatorScraper(LegislatorScraper):
                 )[-1].split(".", 1)[0]
 
             full_name = re.sub("\s+", " ", full_name).strip()
+            email = (
+                'rep{0:0{width}}@ohiohouse.gov' \
+                if chamber == 'lower' else \
+                'sd{0:0{width}}@ohiosenate.gov'
+            ).format(int(district), width=2)
+            print email
             leg = Legislator(term, chamber, district, full_name,
                              party=party, url=homepage, photo_url=img)
 
             leg.add_office('capitol', 'Capitol Office',
                            address=office,
-                           phone=phone)
+                           phone=phone,
+                           email=email)
 
             self.scrape_homepage(leg, chamber, homepage, term)
 


### PR DESCRIPTION
Ohio representatives and senators do not have their email addresses listed on their official websites, but the addresses can be reliably generated based on the district number. See, e.g.:

* House: http://www.semasan.com/page.asp?content=aa_2014OH2&g=SEMAGA
* Senate: http://www.oh-municipalities.com/publication/index.php?i=183210&m=&l=&p=122&pre=&ver=html