### PR TITLE
OK: Modest update

### DIFF
--- a/openstates/mn/legislators.py
+++ b/openstates/mn/legislators.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from cStringIO import StringIO
 from billy.scrape.legislators import Legislator, LegislatorScraper
 from billy.scrape import NoDataForPeriod
-from openstates.utils import LXMLMixin
+from openstates.utils import LXMLMixin, validate_email_address
 
 
 class MNLegislatorScraper(LegislatorScraper, LXMLMixin):
@@ -27,16 +27,6 @@ class MNLegislatorScraper(LegislatorScraper, LXMLMixin):
 
         return is_valid
 
-    def _validate_email_address(self, email_address):
-        is_valid = False
-
-        email_pattern = re.compile(r'\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.'
-            r'[a-zA-Z]{2,}\b')
-        email_match = email_pattern.match(email_address)
-        if email_match is not None:
-            is_valid = True
-
-        return is_valid
 
     def scrape(self, chamber, term):
         getattr(self, 'scrape_' + chamber + '_chamber')(term)
@@ -98,7 +88,7 @@ class MNLegislatorScraper(LegislatorScraper, LXMLMixin):
                 need_special_email_case = True
 
             email_text = email_text.replace('Email: ', '').strip()
-            if self._validate_email_address(email_text):
+            if validate_email_address(email_text):
                 email = email_text
 
             legislator = Legislator(

--- a/openstates/ok/legislators.py
+++ b/openstates/ok/legislators.py
@@ -1,7 +1,7 @@
 import re
 import lxml.html
 from billy.scrape.legislators import LegislatorScraper, Legislator
-from openstates.utils import LXMLMixin
+from openstates.utils import LXMLMixin, validate_email_address
 
 
 class OKLegislatorScraper(LegislatorScraper, LXMLMixin):
@@ -13,6 +13,22 @@ class OKLegislatorScraper(LegislatorScraper, LXMLMixin):
     def _scrub(self, text):
         """Squish whitespace and kill \xa0."""
         return re.sub(r'[\s\xa0]+', ' ', text)
+
+    def _extract_email(self, doc):
+        xpath = '//div[@class="districtheadleft"]' \
+                + '/b[contains(text(), "Email:")]' \
+                + '/../following-sibling::div' \
+                + '/script/text()'
+        script = doc.xpath(xpath)[0]
+        line = filter(
+            lambda line: '+ "@" +' in line,
+            script.split('\r\n'))[0]
+        parts = re.findall(r'"(.+?)"', line)
+
+        email = ''.join(parts)
+
+        return email if validate_email_address(email) else None
+
 
     def scrape(self, chamber, term):
         getattr(self, 'scrape_' + chamber + '_chamber')(term)
@@ -79,6 +95,7 @@ class OKLegislatorScraper(LegislatorScraper, LXMLMixin):
                 district=district,
                 party=party,
                 photo_url=photo_url,
+                url=legislator_url
             )
 
             legislator.add_source(url)
@@ -114,12 +131,10 @@ class OKLegislatorScraper(LegislatorScraper, LXMLMixin):
             if not phone:
                 phone = None
 
-            # Set the email on the legislator object.
-            try:
-                xpath = '//a[contains(@href, "mailto")]/@href'
-                email = doc.xpath(xpath)[0][7:]
-            except IndexError:
-                email = None
+            # Get the email address, extracted from a series of JS
+            # "document.write" lines.
+            email = self._extract_email(doc)
+            legislator['email'] = email
 
             office = dict(
                 name='Capitol Office', type='capitol', phone=phone, email=email, address=address)
@@ -141,7 +156,7 @@ class OKLegislatorScraper(LegislatorScraper, LXMLMixin):
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)
 
-        for a in doc.xpath('//table[@summary]')[1].xpath('.//td//a[contains(@href, "biographies")]'):
+        for a in doc.xpath('//table[@summary]')[0].xpath('.//td//a[contains(@href, "biographies")]'):
             tail = a.xpath('..')[0].tail
             if tail:
                 district = tail.split()[1]
@@ -152,12 +167,8 @@ class OKLegislatorScraper(LegislatorScraper, LXMLMixin):
                 self.warning("District {} appears to be empty".format(district))
                 continue
             else:
-                name, party = a.text.rsplit(None, 1)
-
-            if party == '(D)':
-                party = 'Democratic'
-            elif party == '(R)':
-                party = 'Republican'
+                match = re.match(r'(.+) \(([A-Z])\)', a.text.strip())
+                name, party = match.group(1), self._parties[match.group(2)]
 
             url = a.get('href')
 
@@ -182,24 +193,39 @@ class OKLegislatorScraper(LegislatorScraper, LXMLMixin):
         # Add the capitol office.
         col1 = map(self._scrub, col1.itertext())
         while True:
-            # Throw away anything after the email address.
+            # Throw away anything after one of the email address, phone number,
+            # and last line of address.
             last = col1[-1]
-            if '@' not in last and not re.search(r'[\d\-\(\) ]{7,}', last):
+            if '@' not in last \
+               and ', OK' not in last \
+               and not re.search(r'[\d\-\(\) ]{7,}', last):
                 col1.pop()
             else:
                 break
 
         # Set email on the leg object.
-        email = col1.pop()
-        legislator['email'] = email
+        if '@' in col1[-1]:
+            email = col1.pop()
+            legislator['email'] = email
+        else:
+            email = None
 
-        # Next line is the phone number.
-        phone = col1.pop()
+        phone = filter(
+            lambda string: re.search(
+                r'\(\d{3}\) \d{3}-\d{4}|\d{3}.\d{3}.\d{4}', string),
+            col1)[0].strip()
+
+        address_lines = map(
+            lambda line: line.strip(),
+            filter(
+                lambda string: re.search(r', OK|Lincoln Blvd|Room \d', string),
+                col1))
+
         office = dict(
             name='Capitol Office',
             type='capitol',
-            address='\n'.join(col1),
-            fax=None, email=None, phone=phone)
+            address='\n'.join(address_lines),
+            fax=None, email=email, phone=phone)
         legislator.add_office(**office)
 
         col2 = map(self._scrub, col2.itertext())

--- a/openstates/utils/__init__.py
+++ b/openstates/utils/__init__.py
@@ -1,1 +1,13 @@
 from .lxmlize import LXMLMixin
+import re
+
+def validate_email_address(email_address):
+    is_valid = False
+
+    email_pattern = re.compile(r'\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.'
+                               r'[a-zA-Z]{2,}\b')
+    email_match = email_pattern.match(email_address)
+    if email_match is not None:
+        is_valid = True
+
+    return is_valid


### PR DESCRIPTION
    - Handle variances in senators' name, party, and office details format
    - Extract representatives' email addresses
    - Reuse email validation function from mn.legislators, moving it to
      openstates.utils

An example of one of the more aberrant senator pages is that of J.J. Dossett (http://www.oksenate.gov/Senators/biographies/dossett_bio.aspx). If the moving over of the validation function is not the preferred solution, I'm happy to adjust and resubmit.