### PR TITLE
WA: Accounted for bill documents not beginning with a bill number.

### DIFF
--- a/openstates/wa/bills.py
+++ b/openstates/wa/bills.py
@@ -113,7 +113,8 @@ class WABillScraper(BillScraper, LXMLMixin):
 
                 (bill_number, is_substitute, substitute_num, is_engrossed,
                     engrossed_num, document_title) = re.search(r'''(?x)
-                    ^(\d+)  # Bill number
+                    (?:[[A-Z]+]){0,1} # Occasional doc doesnt start with number
+                    (\d+)  # Bill number
                     (-S(\d)?)?  # Substitution indicator
                     (\.E(\d)?)?  # Engrossment indicator
                     \s?(.*?)  # Document name


### PR DESCRIPTION
Thanks to @Skekacs93 for the underlying fix.  Needed to tweak the regex.