### PR TITLE
Fixed bug where blank IdenticalBillNumber broke NJ scraper

### DIFF
--- a/openstates/nj/bills.py
+++ b/openstates/nj/bills.py
@@ -185,8 +185,9 @@ class NJBillScraper(BillScraper, MDBMixin):
 
             bill = Bill(str(session), chamber, bill_id, title,
                         type=self._bill_types[bill_type[1:]])
-            if rec['IdenticalBillNumber']:
+            if rec['IdenticalBillNumber'].strip():
                 bill.add_companion(rec['IdenticalBillNumber'].split()[0])
+
             # TODO: last session info is in there too
             bill_dict[bill_id] = bill
 


### PR DESCRIPTION
New Jersey added a bill to their DB with an IdenticalBillNumber that existed but was just whitespace, which was causing an error on line 189 of NJ bills.py:

line 189, in scrape_bills
    bill.add_companion(rec['IdenticalBillNumber'].split()[0])
IndexError: list index out of range

This patch fixes that issue so that an IdenticalBillNumber of '  ' doesn't evaluate to true and trigger the if loop.