### PR TITLE
Fixed embedded HTML in LA event location breaking scraper

### DIFF
--- a/openstates/la/events.py
+++ b/openstates/la/events.py
@@ -136,7 +136,8 @@ class LAEventScraper(EventScraper, LXMLMixin):
                 # dead entries.
 
             committee_name = meeting.xpath('./td[1]/text()')[0].strip()
-            meeting_string = meeting.xpath('./td[2]/text()')[0]
+            meeting_string = meeting.xpath('./td[2]')[0].text_content()
+            
             if "@" in meeting_string:
                 continue  # Contains no time data.
             date, time, location = ([s.strip() for s in meeting_string.split(


### PR DESCRIPTION
The scraper was failing due to embedded HTML in the last meeting here http://house.louisiana.gov/H_Sched/Hse_MeetingSchedule.aspx -- so strip out the HTML from the table cell we need.