### PR TITLE
Added additional ordinals missing in WA bill scraper

### DIFF
--- a/openstates/wa/bills.py
+++ b/openstates/wa/bills.py
@@ -24,6 +24,11 @@ class WABillScraper(BillScraper, LXMLMixin):
         '2': 'Second',
         '3': 'Third',
         '4': 'Fourth',
+        '5': 'Fifth',
+        '6': 'Sixth',
+        '7': 'Seventh',
+        '8': 'Eighth',
+        '9': 'Ninth',
         '': ''
     }
 


### PR DESCRIPTION
WA bill scraper was failing due to a missing ordinal for '5', so I added the next few in the sequence just to be safe.