### PR TITLE
OK: added SCHEDULED CCR to Committee Report document check

### DIFF
--- a/openstates/ok/bills.py
+++ b/openstates/ok/bills.py
@@ -123,7 +123,7 @@ class OKBillScraper(BillScraper):
             version_url = link.attrib['href']
             name = link.text.strip()
 
-            if 'COMMITTEE REPORTS' in version_url:
+            if re.search('COMMITTEE REPORTS|SCHEDULED CCR', version_url):
                 bill.add_document(name, version_url, mimetype='application/pdf')
                 continue
 


### PR DESCRIPTION
The scraper was attempting to add the last two Conference Committee Reports as bill versions: http://www.oklegislature.gov/BillInfo.aspx?Bill=SB85&session=1600. 