### PR TITLE
OK: Made filter regex case-insensitive.

### DIFF
--- a/openstates/ok/bills.py
+++ b/openstates/ok/bills.py
@@ -123,7 +123,7 @@ class OKBillScraper(BillScraper):
             version_url = link.attrib['href']
             name = link.text.strip()
 
-            if re.search('COMMITTEE REPORTS|SCHEDULED CCR', version_url):
+            if re.search('COMMITTEE REPORTS|SCHEDULED CCR', version_url, re.IGNORECASE):
                 bill.add_document(name, version_url, mimetype='application/pdf')
                 continue
 


### PR DESCRIPTION
This is because the URLs we filter on are not in a consistent case.