### PR TITLE
IA: Added senate resolutions to vote block end indicators.

### DIFF
--- a/openstates/ia/votes.py
+++ b/openstates/ia/votes.py
@@ -158,6 +158,7 @@ class IAVoteScraper(InvalidHTTPSScraper, VoteScraper):
             ('Present', 'skip'),
             ('Amendment', DONE),
             ('Resolution', DONE),
+            ('The senate joint resolution', DONE),
             ('Bill', DONE),
 
             # House journal.


### PR DESCRIPTION
The last block of names for S.J.R. 2007 in the [Iowa Senate Journal](https://www.legis.iowa.gov/docs/Pubs/sjweb/PDF2/2016/02-24-2016.pdf) was also pulling in the remaining text of the document because it was not properly reading an indicator for the end of the block.