### PR TITLE
Fixed date value out of range error in california db download script 

### DIFF
--- a/openstates/ca/download.py
+++ b/openstates/ca/download.py
@@ -286,9 +286,15 @@ def get_contents():
         date = date.replace('  ', ' ')
         try:
             date = datetime.strptime(date, '%b %d %Y')
-        except ValueError:
-            date = datetime.strptime(date, '%b %d %H:%M')
-            date = date.replace(year=datetime.now().year)
+        except ValueError as e:
+            #The string "Feb 29 21:32" breaks the parser due to a Feb 29 without a (leap) year.
+            if re.match('Feb 29',date):
+                date = '%s %s' % (date, '2016')
+                date = datetime.strptime(date, '%b %d %H:%M %Y')
+            else: 
+                date = datetime.strptime(date, '%b %d %H:%M')
+                date = date.replace(year=datetime.now().year)
+            
         resp[filename] = date
     return resp
 


### PR DESCRIPTION
The script that downloads the California bill database breaks now, because there's a date of Feb 29 without a year, which throws a date value out of range error.

This patch adds a special case. The 2020 leap day is on a Saturday, so I just hard coded a Feb 29 check rather than try to infer the date since we should be good for 8 years.