### PR TITLE
NM: add committee scraper, remove committee roles from legislators scraper

### DIFF
--- a/openstates/nm/__init__.py
+++ b/openstates/nm/__init__.py
@@ -3,6 +3,7 @@ import scrapelib
 import lxml.html
 from billy.scrape.utils import url_xpath
 from .bills import NMBillScraper
+from .committees import NMCommitteeScraper
 from .legislators import NMLegislatorScraper
 
 UAS = scrapelib._user_agent = "Mozilla/5.0 (compatible; %s)" % (

--- a/openstates/nm/committees.py
+++ b/openstates/nm/committees.py
@@ -1,0 +1,104 @@
+from billy.scrape.committees import CommitteeScraper, Committee
+from openstates.utils import LXMLMixin
+
+base_url = 'http://www.nmlegis.gov:8080/Committee/'
+
+
+class NMCommitteeScraper(CommitteeScraper, LXMLMixin):
+    jurisdiction = 'nm'
+
+    def scrape(self, chamber, term):
+        self.validate_term(term)
+
+        # Xpath query string format for legislative chamber committee urls
+        base_xpath = '//table[@id="MainContent_gridView{0}Committees"]' \
+                     '//a[contains(@id, "MainContent_gridView{1}Committees_link{2}Committee")]/@href'
+
+        if chamber == 'upper':
+            url = '{}Senate_Standing'.format(base_url)
+            chamber_xpath = base_xpath.format('Senate', 'Senate', 'Senate')
+
+            # Most interim committees are joint. Use 'joint' chamber as the way
+            # to collect Interim committee data
+            self.scrape('joint', term)
+
+        elif chamber == 'lower':
+            url = '{}House_Standing'.format(base_url)
+            chamber_xpath = base_xpath.format('House', 'House', 'House')
+
+        elif chamber == 'joint':
+            url = '{}Interim'.format(base_url)
+            chamber_xpath = base_xpath.format('', '', '')
+
+        self.debug('Scraping NM {0} chamber term {1} for committees listed at {2}'.format(chamber, term, url))
+
+        page = self.lxmlize(url)
+
+        committee_urls = self.get_nodes(page, chamber_xpath)
+
+        for committee_url in committee_urls:
+            self.scrape_committee(chamber, committee_url)
+
+    def scrape_committee(self, chamber, url):
+
+        committee_page = self.lxmlize(url)
+
+        name_node = self.get_node(committee_page, '//table[@id="MainContent_formViewCommitteeInformation"]/tr//h3')
+
+        c_name = name_node.text_content().strip() if name_node is not None and name_node.text_content() else None
+
+        if c_name:
+            committee = Committee(chamber, c_name.replace('House ', '').replace('Senate ', ''))
+
+            members_xpath = '//table[@id="MainContent_formViewCommitteeInformation_gridViewCommitteeMembers"]' \
+                            '/tbody/tr'
+            members = self.get_nodes(committee_page, members_xpath)
+
+            tds = {
+                'title': 0,
+                'name': 1,
+                'role': 3
+            }
+
+            for member in members:
+                m_title = member[tds['title']].text_content()
+                m_name = self.get_node(member[tds['name']],
+                                       './/a[contains(@href, "/Members/Legislator?SponCode=")]').text_content()
+                role = member[tds['role']].text_content()
+
+                if m_title == 'Senator':
+                    m_chamber = 'upper'
+                elif m_title == 'Representative':
+                    m_chamber = 'lower'
+                else:
+                    m_chamber = None
+
+                if role in ('Chair', 'Co-Chair', 'Vice Chair', 'Member', 'Advisory'):
+                    if chamber == 'joint':
+                        m_role = 'interim {}'.format(role.lower())
+                    else:
+                        m_role = role.lower()
+                else:
+                    m_role = None
+
+                if m_role:
+                    committee.add_member(m_name, m_role, chamber=m_chamber)
+
+            # Interim committees are collected during the scraping for joint committees,
+            # and most interim committees have members from both chambers. However, a small
+            # number of interim committees (right now, just 1) have only members from one
+            # chamber, so the chamber is set to their chamber instead of 'joint'
+            # for those committees.
+            if chamber == 'joint':
+                m_chambers = set([mem['chamber'] for mem in committee['members']])
+                if len(m_chambers) == 1:
+                    committee['chamber'] = m_chambers.pop()
+
+            if not committee['members']:
+                self.warning('skipping blank committee {0} at {1}'.format(c_name, url))
+            else:
+                committee.add_source(url)
+                self.save_committee(committee)
+
+        else:
+            self.warning('No legislative committee found at {}'.format(url))

--- a/openstates/nm/committees.py
+++ b/openstates/nm/committees.py
@@ -84,20 +84,20 @@ class NMCommitteeScraper(CommitteeScraper, LXMLMixin):
                 if m_role:
                     committee.add_member(m_name, m_role, chamber=m_chamber)
 
-            # Interim committees are collected during the scraping for joint committees,
-            # and most interim committees have members from both chambers. However, a small
-            # number of interim committees (right now, just 1) have only members from one
-            # chamber, so the chamber is set to their chamber instead of 'joint'
-            # for those committees.
-            if chamber == 'joint':
-                m_chambers = set([mem['chamber'] for mem in committee['members']])
-                if len(m_chambers) == 1:
-                    committee['chamber'] = m_chambers.pop()
-
             if not committee['members']:
                 self.warning('skipping blank committee {0} at {1}'.format(c_name, url))
             else:
                 committee.add_source(url)
+                # Interim committees are collected during the scraping for joint committees,
+                # and most interim committees have members from both chambers. However, a small
+                # number of interim committees (right now, just 1) have only members from one
+                # chamber, so the chamber is set to their chamber instead of 'joint'
+                # for those committees.
+                if chamber == 'joint':
+                    m_chambers = set([mem['chamber'] for mem in committee['members']])
+                    if len(m_chambers) == 1:
+                        committee['chamber'] = m_chambers.pop()
+
                 self.save_committee(committee)
 
         else:

--- a/openstates/nm/committees.py
+++ b/openstates/nm/committees.py
@@ -4,6 +4,15 @@ from openstates.utils import LXMLMixin
 base_url = 'http://www.nmlegis.gov:8080/Committee/'
 
 
+def clean_committee_name(name_to_clean):
+    head, separator, tail = name_to_clean.replace('House ', '')\
+        .replace('Senate ', '')\
+        .replace('Subcommittee', 'Committee')\
+        .rpartition(' Committee')
+
+    return head + tail
+
+
 class NMCommitteeScraper(CommitteeScraper, LXMLMixin):
     jurisdiction = 'nm'
 
@@ -48,7 +57,7 @@ class NMCommitteeScraper(CommitteeScraper, LXMLMixin):
         c_name = name_node.text_content().strip() if name_node is not None and name_node.text_content() else None
 
         if c_name:
-            committee = Committee(chamber, c_name.replace('House ', '').replace('Senate ', ''))
+            committee = Committee(chamber, clean_committee_name(c_name))
 
             members_xpath = '//table[@id="MainContent_formViewCommitteeInformation_gridViewCommitteeMembers"]' \
                             '/tbody/tr'

--- a/openstates/nm/legislators.py
+++ b/openstates/nm/legislators.py
@@ -169,28 +169,4 @@ class NMLegislatorScraper(LegislatorScraper, LXMLMixin):
             phone=capitol_phone,
             email=email)
 
-        committees_nodes = self.get_nodes(
-            info_node,
-            '//table[@id="ctl00_mainCopy_gridViewCommittees"]/tr')
-
-        # First row node should contain header - skip.
-        for committee_node in committees_nodes[1:]:
-            role, committee, note = [x.text_content() for x in committee_node\
-                .xpath('./td')]
-            committee = committee.title()
-            if 'Interim' in note:
-                role = 'interim ' + role.lower()
-            else:
-                role = role.lower()
-            if ' Committee' in committee:
-                committee = committee.replace(" Committee", '')
-            if ' Subcommittee' in committee:
-                committee = committee.replace(' Subcommittee', '')
-            legislator.add_role(
-                'committee member',
-                term,
-                committee=committee,
-                position=role,
-                chamber=chamber)
-
         self.save_legislator(legislator)


### PR DESCRIPTION
This is for [DATA-499](https://sunlight.atlassian.net/projects/DATA/issues/DATA-499).

Data is being pulled from the NM legislature's [new site](http://www.nmlegis.gov:8080/). Specifically, http://www.nmlegis.gov:8080/Committee/Default is the root from which committee scraping starts.

This version of the scraper maintains the use of "interim member," "interim co-chair," etc. that the legislator scraper was assigning when it was used to get committee information. It seems that in NM's case "interim" does not seem to mean "temporary until something permanent comes along." "Interim" seems to mean committees that meet when the legislature is not in session. At least that's what I gathered [by Googling](https://www.google.com/webhp?#q=new%20mexico%20legislature%20interim%20committees). If that is true, perhaps "chair" is a more accurate role than "interim chair." If this is something that should be changed, let me know, and I can remove the "interim" part of the role.

The committee scraper also follows the legislators' scraper's policy of removing "Committee" and "Subcommittee" from the name of each committee. Is that the expected practice for openstates.org data?

Note that most interim committees are joint legislative committees, and this was not being captured when the committee information was derived from the legislator scraper.