### PR TITLE
RI: minor events scraper fix (catches 'Rise of House' as time)

### DIFF
--- a/openstates/ri/events.py
+++ b/openstates/ri/events.py
@@ -68,7 +68,7 @@ class RIEventScraper(EventScraper, LXMLMixin):
             return
 
         event_desc = "Meeting Notice"
-        if "Rise of the" in datetime:
+        if "Rise of" in datetime:
             datetime = date
             kwargs["all_day"] = True
             event_desc = "Meeting Notice: Starting at {}".format(time)


### PR DESCRIPTION
http://status.rilin.state.ri.us/documents/agenda-11786.aspx