### PR TITLE
ND: Preserve vertical whitespace in addresses

### DIFF
--- a/openstates/nd/legislators.py
+++ b/openstates/nd/legislators.py
@@ -55,7 +55,7 @@ class NDLegislatorScraper(LegislatorScraper):
         address = page.xpath("//div[@class='adr']")
         if address:
             address = address[0]
-            address = re.sub("\s+", " ", address.text_content()).strip()
+            address = re.sub("[ \t]+", " ", address.text_content()).strip()
         else:
             address = None
 


### PR DESCRIPTION
Street names in North Dakota appear rife with directional suffixes. This is a tiny patch to prevent ambiguous addresses such as "752 51st Street South Fargo, ND" (the city of Fargo and not South Fargo) and "1822 Brentwood Court West Fargo, ND" (the city is West Fargo and not Fargo).