### PR TITLE
CT: minor exception for bill versions with extra 1 at beginning

### DIFF
--- a/openstates/ct/bills.py
+++ b/openstates/ct/bills.py
@@ -271,7 +271,7 @@ class CTBillScraper(BillScraper):
         files = parse_directory_listing(page)
 
         for f in files:
-            match = re.match(r'^\d{4,4}([A-Z]+-\d{5,5})-(R\d\d)',
+            match = re.match(r'^\d{4,5}([A-Z]+-\d{5,5})-(R\d\d)',
                              f.filename)
             bill_id = match.group(1).replace('-', '')
 


### PR DESCRIPTION
The first couple of versions here (ftp://ftp.cga.ct.gov/2016/tob/h/) have an extra '1', that was breaking the bills scraper.