### PR TITLE
NM: reference NM legislature's new site in bill scraping

### DIFF
--- a/openstates/nm/__init__.py
+++ b/openstates/nm/__init__.py
@@ -108,8 +108,8 @@ metadata = {
 
 
 def session_list():
-    return url_xpath('http://www.nmlegis.gov:8080/',
-        '//select[@name="ctl00$MainContent$ddlSessions"]/option/text()')
+    return url_xpath('http://www.nmlegis.gov/lcs/keyword.aspx',
+        '//select[@name="ctl00$mainCopy$ddlSessions"]/option/text()')
 
 
 def extract_text(doc, data):

--- a/openstates/nm/__init__.py
+++ b/openstates/nm/__init__.py
@@ -108,8 +108,8 @@ metadata = {
 
 
 def session_list():
-    return url_xpath('http://www.nmlegis.gov/lcs/keyword.aspx',
-        '//select[@name="ctl00$mainCopy$ddlSessions"]/option/text()')
+    return url_xpath('http://www.nmlegis.gov:8080/',
+        '//select[@name="ctl00$MainContent$ddlSessions"]/option/text()')
 
 
 def extract_text(doc, data):

--- a/openstates/nm/bills.py
+++ b/openstates/nm/bills.py
@@ -183,8 +183,8 @@ class NMBillScraper(BillScraper):
                                                       "LegNo", "SessionYear"]})
 
             bill.add_source(
-                'http://www.nmlegis.gov/lcs/legislation.aspx?Chamber='
-                "{Chamber}&LegType={LegType}&LegNo={LegNo}"
+                'http://www.nmlegis.gov:8080/Legislation/Legislation?chamber='
+                "{Chamber}&legType={LegType}&legNo={LegNo}"
                 "&year={SessionYear}".format(**data))
 
             bill.add_sponsor('primary', sponsor_map[data['SponsorCode']])
@@ -262,7 +262,7 @@ class NMBillScraper(BillScraper):
             com_location_map[loc['LocationCode']] = loc['LocationDesc']
 
         # combination of tblActions and
-        # http://www.nmlegis.gov/lcs/action_abbreviations.aspx
+        # http://www.nmlegis.gov:8080/Legislation/Action_Abbreviations
         # table will break when new actions are encountered
         action_map = {
             # committee results
@@ -355,8 +355,8 @@ class NMBillScraper(BillScraper):
                 continue
 
             # ok the whole Day situation is madness, N:M mapping to real days
-            # see http://www.nmlegis.gov/lcs/lcsdocs/legis_day_chart_11.pdf
-            # first idea was to look at all Days and use the first occurance's
+            # see http://www.nmlegis.gov/lcs/lcsdocs/legis_day_chart_16.pdf
+            # first idea was to look at all Days and use the first occurrence's
             # timestamp, but this is sometimes off by quite a bit
             # instead lets just use EntryDate and take radical the position
             # something hasn't happened until it is observed


### PR DESCRIPTION
Sets the "source" for each bill to the location of that bill on the new site. (For example, like http://www.nmlegis.gov:8080/Legislation/Legislation?chamber=H&legType=B&legNo=1&year=16)

Main data is still retrieved from the same ftp location.
Documents (like PDFs for votes) are still retrieved from the same locations. (Fior example, like "http://www.nmlegis.gov/Sessions/16%20Regular/firs/")