### PR TITLE
NM: use new site for session scraping

### DIFF
--- a/openstates/nm/__init__.py
+++ b/openstates/nm/__init__.py
@@ -108,8 +108,9 @@ metadata = {
 
 
 def session_list():
-    return url_xpath('http://www.nmlegis.gov/lcs/keyword.aspx',
-        '//select[@name="ctl00$mainCopy$ddlSessions"]/option/text()')
+    return url_xpath('http://www.nmlegis.gov:8080/',
+                     '//select[@name="ctl00$MainContent$ddlSessions"]'
+                     '/option/text()')
 
 
 def extract_text(doc, data):


### PR DESCRIPTION
Retrieve sessions from the options on the main page of the new NM legislature site.