### PR TITLE
RI: added exception to event time

### DIFF
--- a/openstates/ri/events.py
+++ b/openstates/ri/events.py
@@ -79,11 +79,10 @@ class RIEventScraper(EventScraper, LXMLMixin):
             return
 
         event_desc = "Meeting Notice"
-        if "Rise of" in datetime:
+        if re.search("Rise of|Immediately after", datetime):
             datetime = date
             kwargs["all_day"] = True
             event_desc = "Meeting Notice: Starting at {}".format(time)
-
 
         transtable = {
             "P.M" : "PM",


### PR DESCRIPTION
Covers "TIME:	Immediately after the full Finance committee meeting scheduled for the Rise" from http://status.rilin.state.ri.us/documents/agenda-11801.aspx.