### PR TITLE
don't try to add blank actions to bills in ky

### DIFF
--- a/openstates/ky/bills.py
+++ b/openstates/ky/bills.py
@@ -217,8 +217,9 @@ class KYBillScraper(BillScraper, LXMLMixin):
                 # display. capitalize() won't work for this because it
                 # lowercases all other letters.
                 action = (action[0].upper() + action[1:]).strip()
-
-                bill.add_action(actor, action, action_date, type=atype)
+                
+                if action:
+                    bill.add_action(actor, action, action_date, type=atype)
 
         try:
             votes_link = page.xpath(


### PR DESCRIPTION
KY HB15 has an action with a blank in between two semicolons - "; ;". This is being interpreted as blank actions and blowing up the scraper.

http://www.lrc.ky.gov/record/16RS/HB15.htm

This hotfix ignores blank actions to avoid the validation error and allow the scraper to continue.