### PR TITLE
NH Bill Rewrite

### DIFF
--- a/openstates/nh/__init__.py
+++ b/openstates/nh/__init__.py
@@ -1,6 +1,8 @@
 import lxml.html
 from .bills import NHBillScraper
 from .legislators import NHLegislatorScraper
+from .events import NHEventScraper
+from . import utils
 
 metadata = {
     'abbreviation': 'nh',
@@ -48,8 +50,7 @@ metadata = {
                  '_scraped_name': '2016 Session',
                 },                
     },
-    'feature_flags': ['influenceexplorer'],
-
+    'feature_flags': ['subjects', 'influenceexplorer'],
     '_ignored_scraped_sessions': ['2013 Session'],
 }
 

--- a/openstates/nh/__init__.py
+++ b/openstates/nh/__init__.py
@@ -1,7 +1,6 @@
 import lxml.html
 from .bills import NHBillScraper
 from .legislators import NHLegislatorScraper
-from .events import NHEventScraper
 from . import utils
 
 metadata = {

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from billy.scrape.bills import Bill, BillScraper
 from billy.scrape.votes import Vote
 from .utils import build_legislators, legislator_name, db_cursor
+from .legacyBills import NHLegacyBillScraper
 
 body_code = {'lower': 'H', 'upper': 'S'}
 code_body = {'H': 'lower', 'S': 'upper'}
@@ -65,7 +66,15 @@ class NHBillScraper(BillScraper):
         self._subjects = defaultdict(list)
 
     def scrape(self, chamber, session):
-
+        
+        if int(session) < 2016:
+            legacy = NHLegacyBillScraper(self.metadata, self.output_dir, self.strict_validation)
+            legacy.scrape(chamber, session)
+            # This throws an error because object_count isn't being properly incremented, 
+            # even though it saves fine. So fake the output_names
+            self.output_names = ['1']
+            return
+            
         self.cursor.execute(
             "SELECT legislationnbr, documenttypecode, LegislativeBody, LSRTitle, CondensedBillNo, HouseDateIntroduced, legislationID, sessionyear, lsr, SubjectCode FROM Legislation WHERE sessionyear = %s AND LegislativeBody = '%s' " %
             (session, body_code[chamber]))

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -64,11 +64,8 @@ class NHBillScraper(BillScraper):
         self.cursor = self.conn.cursor(as_dict=True)
         self.legislators = {}
         
-        #cache of all the legislators for sponsorship and votes
-
         self.cursor.execute("SELECT TOP 5 legislationnbr, documenttypecode, LegislativeBody, LSRTitle, CondensedBillNo, HouseDateIntroduced, legislationID, sessionyear, lsr FROM Legislation WHERE sessionyear = %s AND LegislativeBody = '%s' " % (session, body_code[chamber]) )
         for row in self.cursor.fetchall():
-            #print row
             bill_id = row['CondensedBillNo']
             bill_title = row['LSRTitle']
             
@@ -83,7 +80,6 @@ class NHBillScraper(BillScraper):
             self.scrape_votes(bill)
             self.scrape_versions(bill)
 
-            print bill
             self.save_bill(bill)
 
             
@@ -109,7 +105,7 @@ class NHBillScraper(BillScraper):
             sponsor = self.legislators[row['employeeNo']]
             sponsor_name = self.legislator_name( sponsor )
             
-            if row['PrimeSponsor'] == '1':
+            if row['PrimeSponsor'] == 1:
                 sponsor_type = 'primary'
             else:
                 sponsor_type = 'cosponsor'

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -147,9 +147,9 @@ class NHBillScraper(BillScraper):
                 # 4 is Not Voting
                 # 6 is Presiding
                 # 3-6 are not counted in the totals
-                if rollcall['Vote'] == '1':
+                if rollcall['Vote'] == 1:
                     vote.yes(full_name)
-                elif rollcall['Vote'] == '2':
+                elif rollcall['Vote'] == 2:
                     vote.no(full_name)
                 else:
                     vote.other(full_name)

--- a/openstates/nh/bills.py
+++ b/openstates/nh/bills.py
@@ -1,6 +1,8 @@
 import os
 import re
 import zipfile
+import pymssql
+
 import datetime as dt
 
 from billy.scrape.bills import Bill, BillScraper
@@ -8,6 +10,8 @@ from billy.scrape.votes import Vote
 
 
 body_code = {'lower': 'H', 'upper': 'S'}
+code_body = {'H':'lower', 'S':'upper'}
+
 bill_type_map = {'B': 'bill',
                  'R': 'resolution',
                  'CR': 'concurrent resolution',
@@ -16,6 +20,8 @@ bill_type_map = {'B': 'bill',
                  'A': "address"
                 }
 action_classifiers = [
+    ('OTP', ['bill:passed']),
+    ('OTPA', ['amendment:passed']),
     ('Ought to Pass', ['bill:passed']),
     ('Passed by Third Reading', ['bill:reading:3', 'bill:passed']),
     ('.*Ought to Pass', ['committee:passed:favorable']),
@@ -48,181 +54,78 @@ class NHBillScraper(BillScraper):
     jurisdiction = 'nh'
 
     def scrape(self, chamber, session):
-        zip_url = self.metadata['session_details'][session]['zip_url']
 
-        fname, resp = self.urlretrieve(zip_url)
-        self.zf = zipfile.ZipFile(open(fname))
-        os.remove(fname)
-
-        # bill basics
-        self.bills = {}         # LSR->Bill
-        self.bills_by_id = {}   # need a second table to attach votes
-        last_line = []
-        for line in self.zf.open('tbllsrs.txt').readlines():
-            line = line.split('|')
-            if len(line) < 36:
-                if len(last_line + line[1:]) == 36:
-                    # combine two lines for processing
-                    # (skip an empty entry at beginning of second line)
-                    line = last_line + line
-                    self.warning('used bad line')
-                else:
-                    # skip this line, maybe we'll use it later
-                    self.warning('bad line: %s' % '|'.join(line))
-                    last_line = line
-                    continue
-            session_yr = line[0]
-            lsr = line[1]
-            title = line[2]
-            body = line[3]
-            type_num = line[4]
-            expanded_bill_id = line[9]
-            bill_id = line[10]
-
-            if body == body_code[chamber] and session_yr == session:
-                if expanded_bill_id.startswith('CACR'):
-                    bill_type = 'constitutional amendment'
-                elif expanded_bill_id.startswith('PET'):
-                    bill_type = 'petition'
-                elif expanded_bill_id.startswith('AR') and bill_id.startswith('CACR'):
-                    bill_type = 'constitutional amendment'    
-                else:
-                    bill_type = bill_type_map[expanded_bill_id.split(' ')[0][1:]]
-
-                if title.startswith('('):
-                    title = title.split(')', 1)[1].strip()
-
-                self.bills[lsr] = Bill(session, chamber, bill_id, title,
-                                       type=bill_type)
-                version_url = VERSION_URL % (session,
-                                             expanded_bill_id.replace(' ', ''))
-                self.bills[lsr].add_version('latest version', version_url,
-                                            mimetype='text/html')
-                self.bills_by_id[bill_id] = self.bills[lsr]
-
-        # load legislators
+        db_user = 'publicuser'
+        db_password = 'PublicAccess'
+        db_address = '216.177.20.245'
+        db_name = 'NHLegislatureDB'        
+        
+        self.conn = pymssql.connect(db_address, db_user, db_password, db_name)
+        self.cursor = self.conn.cursor(as_dict=True)
         self.legislators = {}
-        for line in self.zf.open('tbllegislators.txt').readlines():
-            line = line.split('|')
-            employee_num = line[0]
+        
+        #cache of all the legislators for sponsorship and votes
 
-            # first, last, middle
-            if line[3]:
-                name = '%s %s %s' % (line[2], line[3], line[1])
+        self.cursor.execute("SELECT TOP 5 legislationnbr, documenttypecode, LegislativeBody, LSRTitle, CondensedBillNo, HouseDateIntroduced, legislationID, sessionyear FROM Legislation WHERE sessionyear = %s AND LegislativeBody = '%s' " % (session, body_code[chamber]) )
+        for row in self.cursor.fetchall():
+            #print row
+            bill_id = row['CondensedBillNo']
+            bill_title = row['LSRTitle']
+            
+            bill = Bill(session, chamber, bill_id, bill_title, db_id=row['legislationID'])
+            #self.scrape_actions(bill)
+            self.scrape_sponsors(bill)
+            self.scrape_votes(bill)
+
+            
+    def scrape_actions(self, bill):
+        print bill
+        
+        #Note: Case of legislationID is inconsistent across tables
+        self.cursor.execute("SELECT TOP 2 * FROM Docket WHERE LegislationId = '%s' ORDER BY StatusDate" % (bill['db_id']))
+        for row in self.cursor.fetchall():
+            #add_action(actor, action, date, type=None, committees=None, legislators=None, **kwargs)
+            actor = code_body[ row['LegislativeBody'] ]
+            action = row['description']
+            date = row['date']
+            bill.add_action(actor, action, date)
+            
+    def scrape_sponsors(self, bill):
+        
+        if not self.legislators:
+            self.build_legislators()
+            
+        self.cursor.execute("SELECT employeeNo, PrimeSponsor FROM Sponsors WHERE LegislationId = '%s' AND SponsorWithdrawn = '0'" % (bill['db_id']))
+        for row in self.cursor.fetchall():
+            
+            sponsor = self.legislators[row['employeeNo']]
+            sponsor_name = ' '.join(filter(None,[sponsor['FirstName'], sponsor['MiddleName'], sponsor['LastName']]))
+
+            if row['PrimeSponsor'] == '1':
+                sponsor_type = 'primary'
             else:
-                name = '%s %s' % (line[2], line[1])
+                sponsor_type = 'cosponsor'
+            
+            bill.add_sponsor(sponsor_type, sponsor_name, employeeNo=sponsor['Employeeno'])
+            
+    def scrape_votes(self, bill):
+        #the votes tables don't reference the bill primary key legislationID, so search by the CondensedBillNo and session
+        self.cursor.execute("SELECT LegislativeBody, VoteDate, Question_Motion, Yeas, Nays, Present, Absent FROM RollCallSummary WHERE CondensedBillNo = '%s' AND SessionYear='%s'" % (bill['bill_id'], bill['session']))
+        for row in self.cursor.fetchall():   
+            chamber = code_body[ row['LegislativeBody'] ]
+            
+            other_count = row['Present'] + row['Absent']
+            #__init__(chamber, date, motion, passed, yes_count, no_count, other_count, type='other', **kwargs)
 
-            self.legislators[employee_num] = {'name': name,
-                                              'seat': line[5]}
-            #body = line[4]
-
-        # sponsors
-        for line in self.zf.open('tbllsrsponsors.txt').readlines():
-            session_yr, lsr, seq, employee, primary = line.strip().split('|')
-
-            if session_yr == session and lsr in self.bills:
-                sp_type = 'primary' if primary == '1' else 'cosponsor'
-                try:
-                    self.bills[lsr].add_sponsor(sp_type,
-                                        self.legislators[employee]['name'],
-                                        _code=self.legislators[employee]['seat'])
-                except KeyError:
-                    self.warning("Error, can't find person %s" % employee)
-
-
-        # actions
-        for line in self.zf.open('tbldocket.txt').readlines():
-            # a few blank/irregular lines, irritating
-            if '|' not in line:
-                continue
-
-            (session_yr, lsr, _, timestamp, bill_id, body,
-             action, _) = line.split('|')
-
-            if session_yr == session and lsr in self.bills:
-                actor = 'lower' if body == 'H' else 'upper'
-                time = dt.datetime.strptime(timestamp,
-                                                  '%m/%d/%Y %H:%M:%S %p')
-                action = action.strip()
-                atype = classify_action(action)
-                self.bills[lsr].add_action(actor, action, time, type=atype)
-                amendment_id = extract_amendment_id(action)
-                if amendment_id:
-                    self.bills[lsr].add_document('amendment %s' % amendment_id,
-                                                 AMENDMENT_URL % amendment_id)
-
-        self.scrape_votes(session)
-
-        # save all bills
-        for bill in self.bills.values():
-            bill.add_source(zip_url)
-            self.save_bill(bill)
-
-
-    def scrape_votes(self, session):
-        votes = {}
-        last_line = []
-
-        for line in self.zf.open('tblrollcallsummary.txt'):
-            if line.strip() == "":
-                continue
-
-            line = line.split('|')
-            if len(line) < 14:
-                if len(last_line + line[1:]) == 14:
-                    line = last_line
-                    self.warning('used bad vote line')
-                else:
-                    last_line = line
-                    self.warning('bad vote line %s' % '|'.join(line))
-            session_yr = line[0]
-            body = line[1]
-            vote_num = line[2]
-            timestamp = line[3]
-            bill_id = line[4].strip()
-            yeas = int(line[5])
-            nays = int(line[6])
-            present = int(line[7])
-            absent = int(line[8])
-            motion = line[11].strip() or '[not available]'
-
-            if session_yr == session and bill_id in self.bills_by_id:
-                actor = 'lower' if body == 'H' else 'upper'
-                time = dt.datetime.strptime(timestamp,
-                                                  '%m/%d/%Y %I:%M:%S %p')
-                # TODO: stop faking passed somehow
-                passed = yeas > nays
-                vote = Vote(actor, time, motion, passed, yeas, nays,
-                            other_count=0)
-                votes[body+vote_num] = vote
-                self.bills_by_id[bill_id].add_vote(vote)
-
-        for line in self.zf.open('tblrollcallhistory.txt'):
-            # 2012    | H   | 2    | 330795  | HB309  | Yea |1/4/2012 8:27:03 PM
-            session_yr, body, v_num, employee, bill_id, vote, date \
-                    = line.split('|')
-
-            if not bill_id:
-                continue
-
-            if session_yr == session and bill_id.strip() in self.bills_by_id:
-                try:
-                    leg = self.legislators[employee]['name']
-                except KeyError:
-                    self.warning("Error, can't find person %s" % employee)
-                    continue
-
-                vote = vote.strip()
-                if not body+v_num in votes:
-                    self.warning("Skipping processing this vote:")
-                    self.warning("Bad ID: %s" % ( body+v_num ) )
-                    continue
-
-                #code = self.legislators[employee]['seat']
-                if vote == 'Yea':
-                    votes[body+v_num].yes(leg)
-                elif vote == 'Nay':
-                    votes[body+v_num].no(leg)
-                else:
-                    votes[body+v_num].other(leg)
-                    votes[body+v_num]['other_count'] += 1
+            vote = Vote(chamber, row['VoteDate'], row['Question_Motion'], row['Yeas'], row['Nays'], other_count)        
+            
+    def build_legislators(self):
+        #We need a map of all IDs->People for sponsors and votes
+        #Note: Legislators can sponsor bills or vote then become inactive mid-session, so don't filter by Active
+        self.cursor.execute("SELECT PersonID, Employeeno, FirstName, LastName, MiddleName, LegislativeBody, District FROM Legislators")
+        
+        print "\nBuilding legislators \n"
+        
+        for row in self.cursor.fetchall():
+            #Votes go by employeeNo not PersonId, so index on that.
+            self.legislators[ row['Employeeno'] ] = row

--- a/openstates/nh/legacyBills.py
+++ b/openstates/nh/legacyBills.py
@@ -1,0 +1,228 @@
+import os
+import re
+import zipfile
+import datetime as dt
+
+from billy.scrape.bills import Bill, BillScraper
+from billy.scrape.votes import Vote
+
+
+body_code = {'lower': 'H', 'upper': 'S'}
+bill_type_map = {'B': 'bill',
+                 'R': 'resolution',
+                 'CR': 'concurrent resolution',
+                 'JR': 'joint resolution',
+                 'CO': 'concurrent order',
+                 'A': "address"
+                }
+action_classifiers = [
+    ('Ought to Pass', ['bill:passed']),
+    ('Passed by Third Reading', ['bill:reading:3', 'bill:passed']),
+    ('.*Ought to Pass', ['committee:passed:favorable']),
+    ('Introduced(.*) and (R|r)eferred', ['bill:introduced', 'committee:referred']),
+    ('.*Inexpedient to Legislate', ['committee:passed:unfavorable']),
+    ('Proposed(.*) Amendment', 'amendment:introduced'),
+    ('Amendment .* Adopted', 'amendment:passed'),
+    ('Amendment .* Failed', 'amendment:failed'),
+    ('Signed', 'governor:signed'),
+    ('Vetoed', 'governor:vetoed'),
+]
+VERSION_URL = 'http://www.gencourt.state.nh.us/legislation/%s/%s.html'
+AMENDMENT_URL = 'http://www.gencourt.state.nh.us/legislation/amendments/%s.html'
+
+
+def classify_action(action):
+    for regex, classification in action_classifiers:
+        if re.match(regex, action):
+            return classification
+    return 'other'
+
+
+def extract_amendment_id(action):
+    piece = re.findall('Amendment #(\d{4}-\d+[hs])', action)
+    if piece:
+        return piece[0]
+
+
+class NHLegacyBillScraper(BillScraper):
+    jurisdiction = 'nh'
+
+    def scrape(self, chamber, session):
+        zip_url = self.metadata['session_details'][session]['zip_url']
+
+        fname, resp = self.urlretrieve(zip_url)
+        self.zf = zipfile.ZipFile(open(fname))
+        os.remove(fname)
+
+        # bill basics
+        self.bills = {}         # LSR->Bill
+        self.bills_by_id = {}   # need a second table to attach votes
+        last_line = []
+        for line in self.zf.open('tbllsrs.txt').readlines():
+            line = line.split('|')
+            if len(line) < 36:
+                if len(last_line + line[1:]) == 36:
+                    # combine two lines for processing
+                    # (skip an empty entry at beginning of second line)
+                    line = last_line + line
+                    self.warning('used bad line')
+                else:
+                    # skip this line, maybe we'll use it later
+                    self.warning('bad line: %s' % '|'.join(line))
+                    last_line = line
+                    continue
+            session_yr = line[0]
+            lsr = line[1]
+            title = line[2]
+            body = line[3]
+            type_num = line[4]
+            expanded_bill_id = line[9]
+            bill_id = line[10]
+
+            if body == body_code[chamber] and session_yr == session:
+                if expanded_bill_id.startswith('CACR'):
+                    bill_type = 'constitutional amendment'
+                elif expanded_bill_id.startswith('PET'):
+                    bill_type = 'petition'
+                elif expanded_bill_id.startswith('AR') and bill_id.startswith('CACR'):
+                    bill_type = 'constitutional amendment'    
+                else:
+                    bill_type = bill_type_map[expanded_bill_id.split(' ')[0][1:]]
+
+                if title.startswith('('):
+                    title = title.split(')', 1)[1].strip()
+
+                self.bills[lsr] = Bill(session, chamber, bill_id, title,
+                                       type=bill_type)
+                version_url = VERSION_URL % (session,
+                                             expanded_bill_id.replace(' ', ''))
+                self.bills[lsr].add_version('latest version', version_url,
+                                            mimetype='text/html')
+                self.bills_by_id[bill_id] = self.bills[lsr]
+
+        # load legislators
+        self.legislators = {}
+        for line in self.zf.open('tbllegislators.txt').readlines():
+            line = line.split('|')
+            employee_num = line[0]
+
+            # first, last, middle
+            if line[3]:
+                name = '%s %s %s' % (line[2], line[3], line[1])
+            else:
+                name = '%s %s' % (line[2], line[1])
+
+            self.legislators[employee_num] = {'name': name,
+                                              'seat': line[5]}
+            #body = line[4]
+
+        # sponsors
+        for line in self.zf.open('tbllsrsponsors.txt').readlines():
+            session_yr, lsr, seq, employee, primary = line.strip().split('|')
+
+            if session_yr == session and lsr in self.bills:
+                sp_type = 'primary' if primary == '1' else 'cosponsor'
+                try:
+                    self.bills[lsr].add_sponsor(sp_type,
+                                        self.legislators[employee]['name'],
+                                        _code=self.legislators[employee]['seat'])
+                except KeyError:
+                    self.warning("Error, can't find person %s" % employee)
+
+
+        # actions
+        for line in self.zf.open('tbldocket.txt').readlines():
+            # a few blank/irregular lines, irritating
+            if '|' not in line:
+                continue
+
+            (session_yr, lsr, _, timestamp, bill_id, body,
+             action, _) = line.split('|')
+
+            if session_yr == session and lsr in self.bills:
+                actor = 'lower' if body == 'H' else 'upper'
+                time = dt.datetime.strptime(timestamp,
+                                                  '%m/%d/%Y %H:%M:%S %p')
+                action = action.strip()
+                atype = classify_action(action)
+                self.bills[lsr].add_action(actor, action, time, type=atype)
+                amendment_id = extract_amendment_id(action)
+                if amendment_id:
+                    self.bills[lsr].add_document('amendment %s' % amendment_id,
+                                                 AMENDMENT_URL % amendment_id)
+
+        self.scrape_votes(session)
+
+        # save all bills
+        for bill in self.bills.values():
+            bill.add_source(zip_url)
+            self.save_bill(bill)
+
+
+    def scrape_votes(self, session):
+        votes = {}
+        last_line = []
+
+        for line in self.zf.open('tblrollcallsummary.txt'):
+            if line.strip() == "":
+                continue
+
+            line = line.split('|')
+            if len(line) < 14:
+                if len(last_line + line[1:]) == 14:
+                    line = last_line
+                    self.warning('used bad vote line')
+                else:
+                    last_line = line
+                    self.warning('bad vote line %s' % '|'.join(line))
+            session_yr = line[0]
+            body = line[1]
+            vote_num = line[2]
+            timestamp = line[3]
+            bill_id = line[4].strip()
+            yeas = int(line[5])
+            nays = int(line[6])
+            present = int(line[7])
+            absent = int(line[8])
+            motion = line[11].strip() or '[not available]'
+
+            if session_yr == session and bill_id in self.bills_by_id:
+                actor = 'lower' if body == 'H' else 'upper'
+                time = dt.datetime.strptime(timestamp,
+                                                  '%m/%d/%Y %I:%M:%S %p')
+                # TODO: stop faking passed somehow
+                passed = yeas > nays
+                vote = Vote(actor, time, motion, passed, yeas, nays,
+                            other_count=0)
+                votes[body+vote_num] = vote
+                self.bills_by_id[bill_id].add_vote(vote)
+
+        for line in self.zf.open('tblrollcallhistory.txt'):
+            # 2012    | H   | 2    | 330795  | HB309  | Yea |1/4/2012 8:27:03 PM
+            session_yr, body, v_num, employee, bill_id, vote, date \
+                    = line.split('|')
+
+            if not bill_id:
+                continue
+
+            if session_yr == session and bill_id.strip() in self.bills_by_id:
+                try:
+                    leg = self.legislators[employee]['name']
+                except KeyError:
+                    self.warning("Error, can't find person %s" % employee)
+                    continue
+
+                vote = vote.strip()
+                if not body+v_num in votes:
+                    self.warning("Skipping processing this vote:")
+                    self.warning("Bad ID: %s" % ( body+v_num ) )
+                    continue
+
+                #code = self.legislators[employee]['seat']
+                if vote == 'Yea':
+                    votes[body+v_num].yes(leg)
+                elif vote == 'Nay':
+                    votes[body+v_num].no(leg)
+                else:
+                    votes[body+v_num].other(leg)
+                    votes[body+v_num]['other_count'] += 1

--- a/openstates/nh/utils.py
+++ b/openstates/nh/utils.py
@@ -16,7 +16,7 @@ def build_legislators(cursor):
 
 def legislator_name(legislator):
     # Turn an NH database Legislator row into an english name
-    return ' '.join(filter(None,[legislator['FirstName'], legislator['MiddleName'], legislator['LastName']]))
+    return ' '.join(filter(None,[legislator['FirstName'].strip(), legislator['MiddleName'].strip(), legislator['LastName'].strip()]))
 
 def db_cursor():
     db_user = 'publicuser'

--- a/openstates/nh/utils.py
+++ b/openstates/nh/utils.py
@@ -1,0 +1,28 @@
+import pymssql
+
+def build_legislators(cursor):
+    # Build a dict that maps EmployeeID -> Legislator to simplify fetching sponsors and votes
+    # Note: Legislators can sponsor bills or vote then become inactive mid-session, 
+    # so don't filter by Active
+    legislators = {}
+    
+    cursor.execute("SELECT PersonID, Employeeno, FirstName, LastName, MiddleName, LegislativeBody, District FROM Legislators")
+    for row in cursor.fetchall():
+        #Votes go by employeeNo not PersonId, so index on that.
+        legislators[ row['Employeeno'] ] = row
+
+    return legislators
+
+
+def legislator_name(legislator):
+    # Turn an NH database Legislator row into an english name
+    return ' '.join(filter(None,[legislator['FirstName'], legislator['MiddleName'], legislator['LastName']]))
+
+def db_cursor():
+    db_user = 'publicuser'
+    db_password = 'PublicAccess'
+    db_address = '216.177.20.245'
+    db_name = 'NHLegislatureDB'        
+    
+    conn = pymssql.connect(db_address, db_user, db_password, db_name)
+    return conn.cursor(as_dict=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ numpy
 pyopenssl
 
 #NH Database Connectivity
+#NOTE: on ubuntu you must export PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1 before installing pymssql
 pymssql

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ numpy
 
 #Indiana error handling
 pyopenssl
+
+#NH Database Connectivity
+pymssql


### PR DESCRIPTION
NH stopped updating their bulk data, but has exposed a SQL database for 2016 bill data that updates live.

Output differences:
1. Roll calls on all votes
2. Addition of subjects for bills
3. Removal of hearings from bill actions. Events scraper to come.
4. Support for multiple bill versions
5. Cleaner Bill Action and Vote names.
6. IDing of Primary sponsors vs CoSponsors

The Legacy scraper code is untouched except to rename the NHBillScraper class.

Note: to get this running on OSX you'll need to 
brew install freetds 

on ubuntu:
export PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1
pip install mssql

on windows:
http://www.pymssql.org/en/latest/freetds.html