### PR TITLE
Handle failure when disable_warnings is not available

### DIFF
--- a/openstates/ia/__init__.py
+++ b/openstates/ia/__init__.py
@@ -8,8 +8,11 @@ from .legislators import IALegislatorScraper
 from .events import IAEventScraper
 from .votes import IAVoteScraper
 
-# Silencing unverified HTTPS request warnings.
-requests.packages.urllib3.disable_warnings()
+try:
+    # Silencing unverified HTTPS request warnings.
+    requests.packages.urllib3.disable_warnings()
+except AttributeError:
+    pass
 
 settings = dict(SCRAPELIB_TIMEOUT=240)
 


### PR DESCRIPTION
Fail gracefully if disable_warnings not available.
See [this](https://github.com/jkbrzt/httpie/issues/418)