### PR TITLE
NM: remove port 8080 from addresses.

### DIFF
--- a/openstates/nm/__init__.py
+++ b/openstates/nm/__init__.py
@@ -108,7 +108,7 @@ metadata = {
 
 
 def session_list():
-    return url_xpath('http://www.nmlegis.gov:8080/',
+    return url_xpath('http://www.nmlegis.gov/',
                      '//select[@name="ctl00$MainContent$ddlSessions"]'
                      '/option/text()')
 

--- a/openstates/nm/bills.py
+++ b/openstates/nm/bills.py
@@ -183,7 +183,7 @@ class NMBillScraper(BillScraper):
                                                       "LegNo", "SessionYear"]})
 
             bill.add_source(
-                'http://www.nmlegis.gov:8080/Legislation/Legislation?chamber='
+                'http://www.nmlegis.gov/Legislation/Legislation?chamber='
                 "{Chamber}&legType={LegType}&legNo={LegNo}"
                 "&year={SessionYear}".format(**data))
 
@@ -262,7 +262,7 @@ class NMBillScraper(BillScraper):
             com_location_map[loc['LocationCode']] = loc['LocationDesc']
 
         # combination of tblActions and
-        # http://www.nmlegis.gov:8080/Legislation/Action_Abbreviations
+        # http://www.nmlegis.gov/Legislation/Action_Abbreviations
         # table will break when new actions are encountered
         action_map = {
             # committee results

--- a/openstates/nm/committees.py
+++ b/openstates/nm/committees.py
@@ -1,7 +1,7 @@
 from billy.scrape.committees import CommitteeScraper, Committee
 from openstates.utils import LXMLMixin
 
-base_url = 'http://www.nmlegis.gov:8080/Committee/'
+base_url = 'http://www.nmlegis.gov/Committee/'
 
 
 def clean_committee_name(name_to_clean):

--- a/openstates/nm/legislators.py
+++ b/openstates/nm/legislators.py
@@ -2,7 +2,7 @@ import re
 from billy.scrape.legislators import LegislatorScraper, Legislator
 from openstates.utils import LXMLMixin
 
-base_url = 'http://www.nmlegis.gov:8080/Members/Legislator_List'
+base_url = 'http://www.nmlegis.gov/Members/Legislator_List'
 
 
 def extract_phone_number(phone_number):


### PR DESCRIPTION
The new NM legislature site is live and now works without port 8080 in the addresses. This removes `:8080` from all addresses.