### PR TITLE
VA: fixed votes with abstentions not being parsed

### DIFF
--- a/openstates/va/bills.py
+++ b/openstates/va/bills.py
@@ -12,7 +12,7 @@ BASE_URL = 'http://lis.virginia.gov'
 class VABillScraper(BillScraper):
     jurisdiction = 'va'
 
-    vote_strip_re = re.compile(r'(.+)\((\d{1,2})-Y (\d{1,2})-N\)')
+    vote_strip_re = re.compile(r'(.+)\((\d{1,2})-Y (\d{1,2})-N( (\d{1,2})-A)?\)')
     actor_map = {'House': 'lower', 'Senate': 'upper', 'Governor': 'governor',
                  'Conference': 'conference'}
 


### PR DESCRIPTION
Votes that include abstention values are being skipped. I have updated the regular expression to include an allowance for an abstention count in the vote name.