### PR TITLE
AK missing bills and fix error

### DIFF
--- a/openstates/ak/bills.py
+++ b/openstates/ak/bills.py
@@ -80,7 +80,7 @@ class AKBillScraper(BillScraper):
         for abbr in bill_abbrs:
             bill_type = bill_types[abbr[1:]]
             bill_list_url = ('http://www.legis.state.ak.us/basis/range_multi'
-                             '.asp?session=%s&bill1=%s1&bill2=%s999' %
+                             '.asp?session=%s&bill1=%s1&bill2=%s9999' %
                              (session, abbr, abbr)
                             )
             doc = lxml.html.fromstring(self.get(bill_list_url).text)
@@ -207,7 +207,10 @@ class AKBillScraper(BillScraper):
 
         html = self.get(url).text
         doc = lxml.html.fromstring(html)
-
+        
+        if len(doc.xpath('//pre')) < 2:
+            return
+        
         # Find all chunks of text representing voting reports.
         votes_text = doc.xpath('//pre')[1].text_content()
         votes_text = re_vote_text.split(votes_text)

--- a/openstates/nm/bills.py
+++ b/openstates/nm/bills.py
@@ -233,6 +233,8 @@ class NMBillScraper(BillScraper):
                 match = re.match('([A-Z]+)0*(\d{1,4})', fname)
                 if match:
                     bill_type, bill_num = match.groups()
+                    mimetype = "application/pdf" if fname.lower().endswith("pdf") else "text/html"    
+                    
                     if (chamber == "upper" and bill_type[0] == "S") or (chamber == "lower" and bill_type[0] == "H"):
                         bill_id = bill_type.replace('B', '') + bill_num
                         try:
@@ -242,9 +244,9 @@ class NMBillScraper(BillScraper):
                         else:
                             if doc_type == 'Final Version':
                                 bill.add_version(
-                                    'Final Version', url + fname, mimetype='text/html')
+                                    'Final Version', url + fname, mimetype=mimetype)
                             else:
-                                bill.add_document(doc_type, url + fname)
+                                bill.add_document(doc_type, url + fname, mimetype=mimetype)
 
         check_docs(firs_url, 'Fiscal Impact Report')
         check_docs(lesc_url, 'LESC Analysis')
@@ -442,11 +444,13 @@ class NMBillScraper(BillScraper):
             except KeyError:
                 self.warning('document for unknown bill %s' % fname)
                 continue
+                
+            mimetype = "application/pdf" if fname.lower().endswith("pdf") else "text/html"    
 
             # no suffix = just the bill
             if suffix == '':
                 bill.add_version('introduced version', doc_path + fname,
-                                 mimetype='text/html')
+                                 mimetype=mimetype)
 
             # floor amendments
             elif re.match('F(S|H)\d', suffix):
@@ -459,7 +463,7 @@ class NMBillScraper(BillScraper):
             elif suffix.endswith('S'):
                 committee_name = suffix[:-1]
                 bill.add_version('%s substitute' % committee_name,
-                                 doc_path + fname, mimetype='text/html')
+                                 doc_path + fname, mimetype=mimetype)
             # votes
             elif 'SVOTE' in suffix:
                 vote = self.parse_senate_vote(doc_path + fname)
@@ -477,7 +481,7 @@ class NMBillScraper(BillScraper):
             elif re.match('\w{2,3,4}\d', suffix):
                 committee_name = re.match('[A-Z]+', suffix).group()
                 bill.add_document('%s committee report' % committee_name,
-                                  doc_path + fname)
+                                  doc_path + fname, mimetype=mimetype)
 
             # ignore list, mostly typos reuploaded w/ proper name
             elif suffix in ('HEC', 'HOVTE', 'GUI'):


### PR DESCRIPTION
The AK scraper was failing on a blank journal entry.

It was also missing all bills with number > 999, which are all the bills from the 5 special sessions. I upped the max bill number to 9999.