### PR TITLE
Fix broken NY bill version urls

### DIFF
--- a/openstates/ny/bills.py
+++ b/openstates/ny/bills.py
@@ -259,12 +259,12 @@ class NYBillScraper(BillScraper):
             html_version = version + ' HTML'
             html_url = 'http://assembly.state.ny.us/leg/?sh=printbill&bn='\
                 '{}&term={}'.format(bill_id, self.term_start_year)
-            bill.add_version(html_version, html_version, mimetype='text/html')
+            bill.add_version(html_version, html_url, on_duplicate='use_new', mimetype='text/html')
 
             pdf_version = version + ' PDF'
             pdf_url = 'http://legislation.nysenate.gov/pdf/bills/{}/{}'\
                 .format(self.term_start_year, bill_id)
-            bill.add_version(pdf_version, pdf_version,
+            bill.add_version(pdf_version, pdf_url, on_duplicate='use_new', 
                 mimetype='application/pdf')
 
         # Handling of sources follows. Sources serving either chamber


### PR DESCRIPTION
NY bills were adding versions with bad URLs, by just creating a new bill_version with the version name twice instead of the version name and the URL.

This fixes that, and assumes in case of name conflict that updated urls are correct.